### PR TITLE
Add PraisonAI to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Agentic Context Engine](https://github.com/kayba-ai/agentic-context-engine): Self-improving agents that learn from execution feedback. LangChain integration for agents that curate their own context. ![GitHub Repo stars](https://img.shields.io/github/stars/kayba-ai/agentic-context-engine?style=social)
 - [Astron](https://github.com/iflytek/astron-agent): Enterprise-grade, commercial-friendly agentic workflow platform for building next-generation SuperAgents.
 - [Ailoy](https://github.com/brekkylab/ailoy): A comprehensive framework for building AI agents that run anywhere, with full local-AI and WASM support.
+- [PraisonAI](https://github.com/MervinPraison/PraisonAI): Production-ready Multi-AI Agents framework with self-reflection. Fastest agent instantiation (3.77μs), 100+ LLM support, MCP integration, workflows, memory, and both Python & JavaScript SDKs. ![GitHub Repo stars](https://img.shields.io/github/stars/MervinPraison/PraisonAI?style=social)
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)


### PR DESCRIPTION
## Adding PraisonAI

[PraisonAI](https://github.com/MervinPraison/PraisonAI) is a production-ready Multi-AI Agents framework with self-reflection.

### Key Features:
- **Fastest agent instantiation** (3.77μs) - benchmarked against CrewAI, LangGraph, PydanticAI
- **100+ LLM support** via LiteLLM integration (OpenAI, Anthropic, Gemini, Ollama, etc.)
- **MCP Protocol support** for tool integration
- **Agentic workflows** with route(), parallel(), loop(), repeat() patterns
- **Built-in memory** (short-term, long-term, entity, episodic)
- **Self-reflection** for improved agent responses
- **Both Python & JavaScript SDKs**

### Simple Example:
```python
from praisonaiagents import Agent
agent = Agent(instructions="You are a helpful AI assistant")
agent.start("Write a haiku about AI")
```

### Multi-Agent Example:
```python
from praisonaiagents import Agent, Agents
research_agent = Agent(instructions="Research about AI")
summarise_agent = Agent(instructions="Summarise findings")
agents = Agents(agents=[research_agent, summarise_agent])
agents.start()
```

Thank you for considering this addition!