### PR TITLE
Add Open Agent to Automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [Open Agent](https://github.com/Th0rgal/openagent): Self-hosted control plane for OpenCode AI agents with isolated Linux workspaces, git-backed configuration, and multi-platform dashboards. ![GitHub Repo stars](https://img.shields.io/github/stars/Th0rgal/openagent?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## Description

Adding [Open Agent](https://github.com/Th0rgal/openagent) to the Automation section.

Open Agent is a self-hosted control plane for OpenCode AI agents featuring:
- Isolated Linux workspaces (systemd-nspawn containers)
- Git-backed Library configuration for skills, tools, rules, agents, and MCPs
- Multi-platform dashboards (Next.js web + SwiftUI iOS)
- Real-time mission monitoring with SSE streaming
- MCP server registry

It handles orchestration, workspace isolation, and configuration management while delegating model inference to OpenCode.