### PR TITLE
Add KodeAgent to the list of AI agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Cortex Memory](https://github.com/sopaco/cortex-mem): A complete solution for agent memory, from extraction and vector search to automated optimization, with a REST API, MCP, CLI, and insights dashboard out-of-the-box.
 - [Summoner](https://github.com/Summoner-Network/summoner-agents): Agent-to-agent networking stack (Python SDK + Rust relay) for server-decoupled agents over long-lived TCP sessions. Includes 50+ runnable agent templates, with API integrations (including MCP) and orchestration framework adapters (e.g., LangChain/CrewAI). ![Summoner](https://img.shields.io/github/stars/Summoner-Network?style=social)
 - [LoongFlow](https://github.com/baidu-baige/LoongFlow): A Evolve Agent Development Framework. From atomic components and development frameworks to core scenario Agents ![GitHub Repo stars](https://img.shields.io/github/stars/baidu-baige/LoongFlow?style=social)
+- [KodeAgent](https://github.com/barun-saha/kodeagent): The Minimal Agent Engine. It is a frameworkless, minimalistic approach to building AI agents (ReAct and CodeAct), together with code sandbox and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/barun-saha/kodeagent?style=social)
 
 
 ## Testing and Evaluation


### PR DESCRIPTION
Hello,

I'd like to add [KodeAgent](https://github.com/barun-saha/kodeagent) to the list of agent frameworks—even though KodeAgent is frameworkless :)

KodeAgent is a minimalistic approach to build ReAct and CodeAct agents. It is lightweight, has minimal dependencies, and integrates easily with other systems. KodeAgent isn't intended to be the whole system, rather the reasoning core behind it.

Links:
- GitHub: https://github.com/barun-saha/kodeagent
- Docs: https://kodeagent.readthedocs.io/en/latest/
- PyPI: https://pypi.org/project/kodeagent/

Let me know if you have any questions.