### PR TITLE
Add KAOS framework to the README agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Summoner](https://github.com/Summoner-Network/summoner-agents): Agent-to-agent networking stack (Python SDK + Rust relay) for server-decoupled agents over long-lived TCP sessions. Includes 50+ runnable agent templates, with API integrations (including MCP) and orchestration framework adapters (e.g., LangChain/CrewAI). ![Summoner](https://img.shields.io/github/stars/Summoner-Network?style=social)
 - [LoongFlow](https://github.com/baidu-baige/LoongFlow): A Evolve Agent Development Framework. From atomic components and development frameworks to core scenario Agents ![GitHub Repo stars](https://img.shields.io/github/stars/baidu-baige/LoongFlow?style=social)
 - [KodeAgent](https://github.com/barun-saha/kodeagent): The Minimal Agent Engine. It is a frameworkless, minimalistic approach to building AI agents (ReAct and CodeAct), together with code sandbox and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/barun-saha/kodeagent?style=social)
+- [KAOS](https://github.com/axsaucedo/kaos): A framework to deploy and manage large scale multi-agent systems in Kubernetes (supports MCP Tools, Hosted/Proxy ModelAPIs, Memory, etc) ![GitHub Repo stars](https://img.shields.io/github/stars/axsaucedo/kaos?style=social)
+
 
 
 ## Testing and Evaluation


### PR DESCRIPTION
Added [KAOS](https://github.com/axsaucedo/kaos) to the `Frameworks` section.

## Description

KAOS is a Kubernetes-native framework for deploying and orchestrating AI agents with tool access, multi-agent coordination, and seamless LLM integration.

## Features

| Feature | Description |
|---------|-------------|
| **Agentic Graphs** | Deploy distributed agents networks as Kubernetes resources |
| **MCP Primitives** | Tool integration via the Model Context Protocol standard |
| **Multi-Agent Support** | Hierarchical agent systems with automatic delegation |
| **OpenAI-Compatible** | All agents expose `/v1/chat/completions` endpoints |
| **KAOS CLI** | Install and manage agents and environments with `kaos` CLI |
| **Visual Dashboard** | UI to monitor agents, test chat, debug memory and tools |