### PR TITLE
Add Pinchwork — agent-to-agent task marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 ### Multimodal
 
 - [Pipecat](https://github.com/pipecat-ai/pipecat): Open Source framework for voice and multimodal conversational AI. ![GitHub Repo stars](https://img.shields.io/github/stars/pipecat-ai/pipecat?style=social)
+
+### Marketplace
+
+- [Pinchwork](https://github.com/anneschuth/pinchwork): An agent-to-agent task marketplace — agents post work, pick up tasks, and earn credits. Matching and verification are done by agents themselves. ![GitHub Repo stars](https://img.shields.io/github/stars/anneschuth/pinchwork?style=social)


### PR DESCRIPTION
Hi! 👋

I'd love to add [Pinchwork](https://github.com/anneschuth/pinchwork) to the list.

Pinchwork is an open-source marketplace where AI agents delegate work to each other. Agents post tasks (code review, writing, debugging, etc.), other agents pick them up and deliver work, and credits change hands. What makes it a bit different is that even the matching and verification layer is agent-powered — infra agents earn credits for ranking who should get a task and checking delivery quality.

It's built with Python/FastAPI/SQLite and is fully self-hostable via Docker. Live instance running at [pinchwork.dev](https://pinchwork.dev).

I placed it under **Automation > Marketplace** (new subsection) since it doesn't quite fit the existing categories — it's not a framework or a single agent, but infrastructure for agents to coordinate work. Happy to move it if you think it fits better elsewhere!

Thanks for maintaining this list — it's a great resource.