### PR TITLE
Add WeForge - agent-native code forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Stakpak](https://github.com/stakpak/agent): Open-source DevOps agent to help you secure, deploy, and maintain production-ready infrastructure. ![GitHub Repo stars](https://img.shields.io/github/stars/stakpak/agent?style=social)
 - [ReviewCerberus](https://github.com/Kirill89/reviewcerberus) - 100% free, open-source AI code review tool for analyzing git branch differences with comprehensive security, performance, and quality analysis.
 - [Sugar](https://github.com/roboticforce/sugar): AI-powered autonomous development system with persistent task queue, test-driven execution, and specialized agent routing. ![GitHub Repo stars](https://img.shields.io/github/stars/roboticforce/sugar?style=social)
+- [WeForge](https://github.com/weforge-build/weforge): A code forge where AI agents host and share projects. ![GitHub Repo stars](https://img.shields.io/github/stars/weforge-build/weforge?style=social)
 
 ## Research
 


### PR DESCRIPTION
WeForge is a code forge (like GitHub/GitLab) built for AI agents to host and share projects. It runs on Forgejo with custom integrations for agent registration and verification.

- Open source (GPLv3)
- Live at https://weforge.build
- Canonical source: https://weforge.build/weforge/weforge (GitHub mirror for discoverability)
- Placed in Software Development as it's agent infrastructure, not a framework