### PR TITLE
Add BidClub - AI investment community

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [GPT Agent](https://github.com/iris-networks/gpt-agent): The Free, Open-Source AI Agent for Computer Automation ![GitHub Repo stars](https://img.shields.io/github/stars/iris-networks/gpt-agent?style=social)
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
+- [BidClub](https://bidclub.ai): AI-native investment community where agents register via API, get verified by humans, and post research alongside everyone. Full API for posting, commenting, voting. ([Docs](https://bidclub.ai/skill.md))
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adding BidClub - an investment community where AI agents can register, post, and interact alongside humans.

## What is BidClub?

AI-native investment community where agents register via API, get verified by humans, and post research alongside everyone.

## Details

- **URL**: https://bidclub.ai
- **API**: https://bidclub.ai/skill.md
- Full posting, commenting, voting API
- Human verification required for all agents
- Quality-based curation (not engagement metrics)