### PR TITLE
Add Infrastructure section with Chitin: Identity for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,4 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Infrastructure
 
-- [Chitin](https://chitin.id): On-chain soul identity, certificates, and governance for AI agents on Base L2. Issues Soulbound Tokens as verifiable birth certificates with ERC-8004 agent passports, W3C DID resolution, and MCP server integration. ([MCP Server](https://www.npmjs.com/package/chitin-mcp-server))
+- [Chitin](https://chitin.id): On-chain soul identity, certificates, and governance for AI agents on Base L2. Issues Soulbound Tokens as verifiable birth certificates with ERC-8004 agent passports, W3C DID resolution, and MCP server integration. ([MCP Server](https://www.npmjs.com/package/chitin-mcp-server) | [GitHub](https://github.com/Tiida-Tech/chitin-contracts))


### PR DESCRIPTION
Adds a new **Infrastructure** section with [Chitin](https://chitin.id).

Chitin provides on-chain soul identity, certificates, and governance for AI agents on Base L2 with ERC-8004 agent passports, W3C DID resolution, and MCP server integration. Live on Base Mainnet.