### PR TITLE
Add Latchkey.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Open Agent](https://github.com/Th0rgal/openagent): Self-hosted control plane for OpenCode AI agents with isolated Linux workspaces, git-backed configuration, and multi-platform dashboards. ![GitHub Repo stars](https://img.shields.io/github/stars/Th0rgal/openagent?style=social)
 - [HyperAgency](https://github.com/vuics/h9y): Agentic AI operating system (h9y.ai) that replaces brittle and fragmented automations with long-lived, self-improving systems. Open-source, decentralized, omni-channel, self-host & cloud, web3 marketplace.
+- [Latchkey](https://github.com/imbue-ai/latchkey): Let agents work on your behalf with arbitrary third-party services (GMail, Dropbox, GitHub, ...) through standard public APIs.
 
 ### Browser
 


### PR DESCRIPTION
https://www.npmjs.com/package/latchkey

Agents can prepend standard `curl` calls with the `latchkey` command to get authentication headers transparently injected.

This way, users can let agents work on their behalf and automate workflows with arbitrary third-party services as long as they offer public APIs. No MCP integrations are needed, no intermediaries are involved.