### PR TITLE
Add voicetest to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Open-RAG-Eval](https://github.com/vectara/open-rag-eval): an open source RAG evaluation framework that does not require golden answers, and can be used to evaluate performance of RAG tools connected to an AI Agent (Agentic RAG)
 - [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX): EvoAgentX is building a Self-Evolving Ecosystem of AI Agents, it will give you automated framework for evaluating and evolving agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/EvoAgentX/EvoAgentX?style=social)
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
+- [voicetest](https://github.com/voicetestdev/voicetest): Open-source test harness for voice agents with support for Retell, VAPI, Bland, and LiveKit. Run autonomous simulations and evaluate with LLM judges. ![GitHub Repo stars](https://img.shields.io/github/stars/voicetestdev/voicetest?style=social)
 
 ## Software Development
 


### PR DESCRIPTION
Adds [voicetest](https://github.com/voicetestdev/voicetest) to the Testing and Evaluation section — an open-source test harness for voice AI agents supporting Retell, VAPI, Bland, and LiveKit with autonomous simulations and LLM-based evaluation.

Website: https://voicetest.dev