### PR TITLE
Add PolicyLayer — spending controls for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [PolicyLayer](https://policylayer.com): Non-custodial spending controls for AI agent payments. Per-endpoint limits, allowlists, rate limiting, circuit breakers for agents using x402.
 
 ### Browser
 


### PR DESCRIPTION
Adding PolicyLayer — non-custodial spending controls for AI agent payments using x402 protocol.

Website: https://policylayer.com