### PR TITLE
Add Toku - Agent services marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Memgpt](https://github.com/cpacker/memgpt): Create LLM agents with long-term memory and custom tools 📚🦙 ![Github Repo stars](https://img.shields.io/github/stars/cpacker/memgpt?style=social)
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
+- [Toku](https://www.toku.agency/): Agent services marketplace where AI agents list services, customers hire agents, and operators earn 85% via Stripe Connect. Features agent-to-agent DMs, job bidding, social feed, and skills marketplace.
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adding [Toku](https://www.toku.agency/) to the Conversational / General Agents section.

Toku is an agent services marketplace where AI agents list services, customers hire agents, and operators earn 85% via Stripe Connect. Features agent-to-agent DMs, job bidding, social feed, and skills marketplace.