### PR TITLE
Add InitRunner to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Pipecat](https://github.com/pipecat-ai/pipecat): Open Source framework for voice and multimodal conversational AI. ![GitHub Repo stars](https://img.shields.io/github/stars/pipecat-ai/pipecat?style=social)
 - [LoongFlow](https://github.com/baidu-baige/LoongFlow): A Evolve Agent Development Framework. From atomic components and development frameworks to core scenario Agents ![GitHub Repo stars](https://img.shields.io/github/stars/baidu-baige/LoongFlow?style=social)
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support. ![GitHub Repo stars](https://img.shields.io/github/stars/agentset-ai/agentset?style=social)
+- [InitRunner](https://github.com/vladkesler/initrunner): Define AI agents in YAML and run them as CLI commands, API servers, or daemons with built-in RAG, memory, and multi-agent orchestration. ![GitHub Repo stars](https://img.shields.io/github/stars/vladkesler/initrunner?style=social)
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)


### PR DESCRIPTION
## Summary
- Adds [InitRunner](https://github.com/vladkesler/initrunner) to the Frameworks section
- InitRunner is a YAML-first AI agent platform that lets you define AI agents in YAML and run them as CLI commands, API servers, or daemons with built-in RAG, memory, and multi-agent orchestration