### PR TITLE
Add SnapRender: screenshot API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [SnapRender](https://github.com/User0856/snaprender-integrations): Screenshot API for AI agents — capture any website as PNG, JPEG, WebP, or PDF. Integrations for LangChain, CrewAI, AutoGen, n8n, and MCP. ![GitHub Repo stars](https://img.shields.io/github/stars/User0856/snaprender-integrations?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## Summary

Adding [SnapRender](https://github.com/User0856/snaprender-integrations) to the Automation section.

SnapRender is a screenshot API for AI agents — capture any website as PNG, JPEG, WebP, or PDF. It provides ready-made integrations for LangChain, CrewAI, AutoGen, n8n, and MCP.