### PR TITLE
Add Manifest — cost observability for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX): EvoAgentX is building a Self-Evolving Ecosystem of AI Agents, it will give you automated framework for evaluating and evolving agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/EvoAgentX/EvoAgentX?style=social)
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [voicetest](https://github.com/voicetestdev/voicetest): Open-source test harness for voice agents with support for Retell, VAPI, Bland, and LiveKit. Run autonomous simulations and evaluate with LLM judges. ![GitHub Repo stars](https://img.shields.io/github/stars/voicetestdev/voicetest?style=social)
+- [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 
 ## Software Development
 


### PR DESCRIPTION
## Summary
- Adds [Manifest](https://manifest.build) ([GitHub](https://github.com/mnfst/manifest)) to the list
- Open-source, real-time cost observability for AI agents
- Tracks tokens, costs, messages, and model usage locally
- 3.3k GitHub stars, MIT licensed, self-hosted

## Why it belongs here
Manifest fills the cost observability gap for AI agents — supporting 28+ LLM models with automatic pricing, security event detection, and standard OTLP ingestion. Local-first, no data leaves the agent.