### PR TITLE
Add nanobot - ultra-lightweight AI agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [LoongFlow](https://github.com/baidu-baige/LoongFlow): A Evolve Agent Development Framework. From atomic components and development frameworks to core scenario Agents ![GitHub Repo stars](https://img.shields.io/github/stars/baidu-baige/LoongFlow?style=social)
 - [Agentset](https://github.com/agentset-ai/agentset): Open-source production-ready RAG platform with built-in agentic reasoning, hybrid search, and multimodal support. ![GitHub Repo stars](https://img.shields.io/github/stars/agentset-ai/agentset?style=social)
 - [hcom](https://github.com/aannoo/hcom): Let AI agents message, watch, and spawn each other across terminals. Claude Code, Gemini CLI, Codex, OpenCode. ![GitHub Repo stars](https://img.shields.io/github/stars/aannoo/hcom?style=social)
+- [nanobot](https://github.com/HKUDS/nanobot): Ultra-lightweight personal AI assistant framework (~4,000 lines of Python). Supports MCP, 9+ chat channels, and extensible skills system. ![GitHub Repo stars](https://img.shields.io/github/stars/HKUDS/nanobot?style=social)
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)


### PR DESCRIPTION
## Description

Added [nanobot](https://github.com/HKUDS/nanobot) - an ultra-lightweight personal AI assistant framework.

### Key Features:
- **Ultra-lightweight**: ~4,000 lines of Python code (99% smaller than OpenClaw)
- **Multi-channel support**: 9+ chat channels (Telegram, Discord, Feishu, WhatsApp, Slack, etc.)
- **MCP support**: Model Context Protocol for extending capabilities
- **Skills system**: Extensible skills with built-in skill registry (ClawHub)
- **Multi-LLM**: Supports OpenRouter, Anthropic, OpenAI, DeepSeek, Gemini, Qwen, etc.

### Stats:
- ⭐ 23k+ GitHub stars
- Active development and community

This addition helps developers discover a lightweight alternative for building personal AI agents.

## Checklist
- [x] Added in alphabetical order
- [x] Added to the Frameworks section
- [x] Included GitHub stars badge