### PR TITLE
Add risk-api to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [risk-api](https://github.com/JleviEderer/risk-api): Smart contract risk scoring agent for EVM chains. Analyzes bytecode patterns, proxy structures, and deployer reputation via A2A protocol with x402 payments. ![GitHub Repo stars](https://img.shields.io/github/stars/JleviEderer/risk-api?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## Summary
- Adds [risk-api](https://github.com/JleviEderer/risk-api) to the Automation section (at the bottom, per CONTRIBUTING.md)
- Open-source smart contract risk scoring agent for EVM chains
- Analyzes bytecode patterns, proxy structures, and deployer reputation
- Uses A2A (Agent-to-Agent) protocol for agent discovery
- Pay-per-call via x402 ($0.10/query in USDC on Base)

## Links
- GitHub: https://github.com/JleviEderer/risk-api
- Live: https://risk-api.life.conway.tech