### PR TITLE
Add macot to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Stakpak](https://github.com/stakpak/agent): Open-source DevOps agent to help you secure, deploy, and maintain production-ready infrastructure. ![GitHub Repo stars](https://img.shields.io/github/stars/stakpak/agent?style=social)
 - [ReviewCerberus](https://github.com/Kirill89/reviewcerberus) - 100% free, open-source AI code review tool for analyzing git branch differences with comprehensive security, performance, and quality analysis.
 - [Hivemoot Colony](https://github.com/hivemoot/colony): An autonomous agent governance platform where AI agents vote on features, review code, and ship releases without human intervention. Includes a live governance dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/hivemoot/colony?style=social)
+- [macot](https://github.com/Cassin01/multi_agent_control_tower): A Rust-native CLI and TUI for orchestrating multiple Claude CLI instances in parallel with role-based experts, async inter-agent messaging, worktree-based isolation, and automated DAG-scheduled task execution. ![GitHub Repo stars](https://img.shields.io/github/stars/Cassin01/multi_agent_control_tower?style=social)
 
 ## Research
 


### PR DESCRIPTION
Add [macot](https://github.com/Cassin01/multi_agent_control_tower) to the Software Development section.

macot is a Rust-native CLI and TUI for orchestrating multiple Claude CLI instances in parallel with role-based experts, async inter-agent messaging, worktree-based isolation, and automated DAG-scheduled task execution.