### PR TITLE
Add WAIaaS to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Swarm](https://github.com/openai/swarm): Educational framework exploring ergonomic, lightweight multi-agent orchestration by OpenAI. ![GitHub Repo stars](https://img.shields.io/github/stars/openai/swarm?style=social)
 - [agency-swarm](https://github.com/VRSEN/agency-swarm): Reliable agent framework built on top of the latest OpenAI Assistants API. ![GitHub Repo stars](https://img.shields.io/github/stars/VRSEN/agency-swarm?style=social)
 - [Upsonic](https://github.com/upsonic/upsonic): Reliable agent framework that supports MCP. ![GitHub Repo stars](https://img.shields.io/github/stars/upsonic/upsonic?style=social)
+- [WAIaaS](https://github.com/minhoyoo-iotrust/WAIaaS): Self-hosted wallet infrastructure for AI agents — multi-chain (EVM + Solana), DeFi operations, policy engine, and MCP server ![GitHub Repo stars](https://img.shields.io/github/stars/minhoyoo-iotrust/WAIaaS?style=social)
 - [Mastra](https://github.com/mastra-ai/mastra): Mastra is an opinionated TypeScript framework that helps you build AI applications and features quickly. ![GitHub Repo stars](https://img.shields.io/github/stars/mastra-ai/mastra?style=social)
 - [Vectara-agentic](https://github.com/vectara/py-vectara-agentic): Vectara-agentic is a framework for creating AI Assistants and agents using Vectara.
 - [Portia AI](https://github.com/portiaAI/portia-sdk-python/) Portia is a new open source agentic Python framework designed for creating reliable agents in production. ![GitHub Repo stars](https://img.shields.io/github/stars/portiaAI/portia-sdk-python?style=social)
@@ -157,4 +158,3 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents): An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
-


### PR DESCRIPTION
Adds WAIaaS — self-hosted wallet infrastructure for AI agents with multi-chain (EVM + Solana), DeFi operations, policy engine, and MCP server — to the Frameworks section.

Placed at the bottom of the Frameworks list per CONTRIBUTING.md guidelines.