### PR TITLE
Add Ratchet to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [hcom](https://github.com/aannoo/hcom): Let AI agents message, watch, and spawn each other across terminals. Claude Code, Gemini CLI, Codex, OpenCode. ![GitHub Repo stars](https://img.shields.io/github/stars/aannoo/hcom?style=social)
 - [nanobot](https://github.com/HKUDS/nanobot): Ultra-lightweight personal AI assistant framework (~4,000 lines of Python). Supports MCP, 9+ chat channels, and extensible skills system. ![GitHub Repo stars](https://img.shields.io/github/stars/HKUDS/nanobot?style=social)
 - [NeuroLink](https://github.com/juspay/neurolink): TypeScript agent framework with multi-step agentic loops, per-step tool execution control (`prepareStep`), persistent memory (Redis/S3/SQLite), HITL workflows, MCP client integration, and 13 LLM providers. ![GitHub Repo stars](https://img.shields.io/github/stars/juspay/neurolink?style=social)
+- [Ratchet](https://github.com/ratchet-framework/Ratchet): Framework for building AI agents that continuously self-improve via structured incident management, persistent memory, and autonomous backlog execution. ([getratchet.dev](https://getratchet.dev))
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)


### PR DESCRIPTION
Adding Ratchet — an engineering framework for building AI agents that self-improve over time through structured incident management.

https://github.com/ratchet-framework/Ratchet

Fits in the Frameworks section. Ratchet defines how an agent gets better (not just what it can do): incident loops, persistent memory, autonomous backlog execution, and trust-tier autonomy progression.