### PR TITLE
Add Agent Wallet SDK to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [nanobot](https://github.com/HKUDS/nanobot): Ultra-lightweight personal AI assistant framework (~4,000 lines of Python). Supports MCP, 9+ chat channels, and extensible skills system. ![GitHub Repo stars](https://img.shields.io/github/stars/HKUDS/nanobot?style=social)
 - [NeuroLink](https://github.com/juspay/neurolink): TypeScript agent framework with multi-step agentic loops, per-step tool execution control (`prepareStep`), persistent memory (Redis/S3/SQLite), HITL workflows, MCP client integration, and 13 LLM providers. ![GitHub Repo stars](https://img.shields.io/github/stars/juspay/neurolink?style=social)
 
+- [Agent Wallet SDK](https://github.com/up2itnow0822/agent-wallet-sdk): Non-custodial smart contract wallets for AI agents — operators transact within owner-set on-chain spend limits (daily + per-tx). TypeScript, Base L2. ![GitHub Repo stars](https://img.shields.io/github/stars/up2itnow0822/agent-wallet-sdk?style=social)
+
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)
 - [Open-RAG-Eval](https://github.com/vectara/open-rag-eval): an open source RAG evaluation framework that does not require golden answers, and can be used to evaluate performance of RAG tools connected to an AI Agent (Agentic RAG)


### PR DESCRIPTION
Adding [Agent Wallet SDK](https://github.com/up2itnow0822/agent-wallet-sdk) to the Frameworks section.

It's a TypeScript SDK that gives AI agents non-custodial smart contract wallets on Base L2. The core idea: agents operate as on-chain "operators" with spend limits the wallet owner sets — daily caps and per-transaction caps, all enforced at the contract level. No key sharing, no custodial risk.

- 267 tests (Forge + SDK + backend)
- Deployed on Base mainnet
- MIT licensed
- npm: `agentwallet-sdk`

I've been building this for a few months now. We're seeing more agents that need to handle real money, and most existing solutions either hand the agent full custody or require a centralized signer. This takes a different approach.