### PR TITLE
Add OpenPaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [OpenPaw](https://github.com/daxaur/openpaw): Turn Claude Code into a personal assistant with 38 skills for email, calendar, Spotify, smart home, Slack, GitHub and more. ![GitHub Repo stars](https://img.shields.io/github/stars/daxaur/openpaw?style=social)
 
 ### Browser
 


### PR DESCRIPTION
Adding OpenPaw — turns Claude Code into a personal assistant. 38 skills (email, calendar, Spotify, smart home, etc), Telegram bridge, task dashboard, scheduling with cost caps. Open source, MIT licensed.