### PR TITLE
Add Human Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [Human Pages](https://github.com/human-pages-ai/humanpages): The open directory AI agents use to hire humans for real-world tasks. Zero platform fees ![GitHub Repo stars](https://img.shields.io/github/stars/human-pages-ai/humanpages?style=social)
 
 ### Browser
 


### PR DESCRIPTION
Adds [Human Pages](https://github.com/human-pages-ai/humanpages) to the Automation section. The open directory AI agents use to hire humans for real-world tasks. Zero platform fees.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages