### PR TITLE
Add MiniClaw — personal AI OS for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Memgpt](https://github.com/cpacker/memgpt): Create LLM agents with long-term memory and custom tools 📚🦙 ![Github Repo stars](https://img.shields.io/github/stars/cpacker/memgpt?style=social)
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
+- [MiniClaw](https://github.com/augmentedmike/miniclaw-os): Personal AI OS for Mac — plugin ecosystem built on OpenClaw with memory, email, project board, cron scheduling, and SEO automation running 24/7 on your own hardware ![GitHub Repo stars](https://img.shields.io/github/stars/augmentedmike/miniclaw-os?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
## Description

Adding [MiniClaw](https://github.com/augmentedmike/miniclaw-os) to the Conversational / General Agents section.

**MiniClaw** is a personal AI OS built on top of OpenClaw (open-source AI agent runtime). It runs 24/7 on a Mac Mini with a plugin ecosystem including:

- `mc-board` — Kanban board with autonomous board-worker agents
- `mc-kb` — Vector memory with local embeddings
- `mc-email` — Gmail integration
- `mc-seo` — Site crawler and on-page audit engine
- `mc-designer` — AI image generation via Gemini
- `mc-trust` — Ed25519 agent identity

Everything runs locally — no subscription, no cloud dependency. The agent can pick up tasks from the board overnight, do the work, and file the results.

Website: https://miniclaw.bot