### PR TITLE
Add Steel Browser to Browser section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,4 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents): An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
-
+- [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source browser infrastructure for AI agents with session-backed automation, extraction, screenshots/PDFs, an AI-native CLI, and a reusable steel-browser skill. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)


### PR DESCRIPTION
This adds Steel Browser to the `Browser` section.

Steel Browser is open-source browser infrastructure for AI agents and apps. It also includes an AI-native CLI and a reusable `steel-browser` skill for session-backed web workflows, extraction, screenshots, PDFs, proxies, and anti-bot-sensitive automation.

Links:
- Browser repo: https://github.com/steel-dev/steel-browser
- CLI: https://github.com/steel-dev/cli
- Skill: https://github.com/steel-dev/cli/tree/main/skills/steel-browser
- Docs: https://docs.steel.dev/
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: use the AI-native CLI or skill to run a browser workflow against a JS-heavy app, extract content, and save screenshot or PDF artifacts.