### PR TITLE
Add Signbee — document signing for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [Signbee](https://github.com/signbee/mcp): Document signing for AI agents — send markdown or PDF for two-party e-signing with SHA-256 certified delivery. MCP server + REST API. ![GitHub Repo stars](https://img.shields.io/github/stars/signbee/mcp?style=social)
 
 ### Browser
 


### PR DESCRIPTION
Adds Signbee to the Automation section. Document signing for AI agents — send markdown or PDF for two-party e-signing with SHA-256 certified delivery. MCP server + REST API.