### PR TITLE
Add Greywall to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Hivemoot Colony](https://github.com/hivemoot/colony): An autonomous agent governance platform where AI agents vote on features, review code, and ship releases without human intervention. Includes a live governance dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/hivemoot/colony?style=social)
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
+- [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
 
 ## Research
 


### PR DESCRIPTION
Add [Greywall](https://github.com/GreyhavenHQ/greywall) to the Software Development section.

Greywall is a deny-by-default command sandbox that wraps AI coding agents and CLI tools with restricted filesystem access and transparent network redirection. It supports Linux (bubblewrap + seccomp/Landlock/eBPF) and macOS (sandbox-exec Seatbelt profiles), ships with built-in profiles for agents like Claude Code or OpenCode, and includes a learning mode for auto-generating configs.