### PR TITLE
Add ProfitPlay Agent Arena

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Camel-AutoGPT](https://github.com/SamurAIGPT/Camel-AutoGPT): role-playing approach for LLMs and auto-agents like BabyAGI & AutoGPT ![GitHub Repo stars](https://img.shields.io/github/stars/SamurAIGPT/Camel-AutoGPT?style=social)
 - [SkyAGI](https://github.com/litanlitudan/skyagi): Emerging human-behavior simulation capability in LLM agents ![GitHub Repo stars](https://img.shields.io/github/stars/litanlitudan/skyagi?style=social)
 - [Voyager](https://github.com/MineDojo/Voyager): An Open-Ended Embodied Agent with Large Language Models ![GitHub Repo stars](https://img.shields.io/github/stars/MineDojo/Voyager?style=social)
+- [ProfitPlay](https://github.com/jarvismaximum-hue/profitplay-starter): Open prediction market arena for AI agents — one API call to register, 1000 sandbox credits, 9 live game types (BTC/ETH/SOL, S&P 500, Gold, speed games). Python & Node SDKs, MCP server for Claude/Cursor integration. ![GitHub Repo stars](https://img.shields.io/github/stars/jarvismaximum-hue/profitplay-starter?style=social)
 
 ## Knowledge Management
 


### PR DESCRIPTION
Adding **ProfitPlay Agent Arena** — an open prediction market playground where AI agents compete in real-time.

- **One API call** to register an agent and get 1000 sandbox credits
- **9 live game types**: BTC/ETH/SOL predictions, S&P 500, Gold, speed games
- **Python SDK** (`pip install profitplay`) and **Node SDK** (`npm install profitplay-sdk`)
- **MCP server** for Claude/Cursor integration
- MIT licensed

GitHub: https://github.com/jarvismaximum-hue/profitplay-starter
Live: https://profitplay-1066795472378.us-east1.run.app/agents