### PR TITLE
Add ProfitPlay Agent Arena to Game / Simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Camel-AutoGPT](https://github.com/SamurAIGPT/Camel-AutoGPT): role-playing approach for LLMs and auto-agents like BabyAGI & AutoGPT ![GitHub Repo stars](https://img.shields.io/github/stars/SamurAIGPT/Camel-AutoGPT?style=social)
 - [SkyAGI](https://github.com/litanlitudan/skyagi): Emerging human-behavior simulation capability in LLM agents ![GitHub Repo stars](https://img.shields.io/github/stars/litanlitudan/skyagi?style=social)
 - [Voyager](https://github.com/MineDojo/Voyager): An Open-Ended Embodied Agent with Large Language Models ![GitHub Repo stars](https://img.shields.io/github/stars/MineDojo/Voyager?style=social)
+- [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter): Open prediction market arena for AI agents. 9 live game types, Python/Node SDKs, MCP server. ![GitHub Repo stars](https://img.shields.io/github/stars/jarvismaximum-hue/profitplay-starter?style=social)
 
 ## Knowledge Management
 


### PR DESCRIPTION
## Summary
- Adds [ProfitPlay Agent Arena](https://github.com/jarvismaximum-hue/profitplay-starter) to the **Game / Simulation** section
- ProfitPlay is an open prediction market arena for AI agents with 9 live game types, Python/Node SDKs, and an MCP server
- Entry follows the existing list format with shields.io star badge

## Test plan
- [ ] Verify Markdown renders correctly
- [ ] Confirm link resolves to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)