### PR TITLE
Add openLight - lightweight AI agent runtime for Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [openLight](https://github.com/evgenii-engineer/openLight) - Lightweight AI agent runtime combining deterministic skills and LLM routing.
 
 ### Browser
 


### PR DESCRIPTION
Hi!

I'd like to add openLight to the list.

openLight is a lightweight AI agent runtime designed for Raspberry Pi and homelabs.   It combines deterministic skill execution with LLM-based routing and supports local models via Ollama.

Thanks!