### PR TITLE
Add OMEGA Memory to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [LLocalSearch](https://github.com/nilsherzig/LLocalSearch): LLocalSearch is a completely locally running search aggregator using LLM Agents. The user can ask a question and the system will use a chain of LLMs to find the answer. The user can see the progress of the agents and the final answer. No OpenAI or Google API keys are needed. ![GitHub Repo stars](https://img.shields.io/github/stars/nilsherzig/LLocalSearch?style=social)
 - [Second Brain AI Agent](https://github.com/flepied/second-brain-agent): A streamlit app to dialog with your second brain notes using OpenAI and ChromaDB locally. ![GitHub Repo stars](https://img.shields.io/github/stars/flepied/second-brain-agent?style=social)
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
+- [OMEGA Memory](https://github.com/omega-memory/omega-memory): Persistent memory, coordination, and learning for AI agents. 25 MCP tools, #1 on LongMemEval (95.4%), local-first with semantic search and multi-agent coordination. ![GitHub Repo stars](https://img.shields.io/github/stars/omega-memory/omega-memory?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Adds OMEGA Memory to the Knowledge Management section.

- Persistent memory for AI agents with 25 MCP tools
- #1 on LongMemEval benchmark (95.4%)
- Local-first, open source (Apache-2.0)
- Works with Claude Code, Cursor, Windsurf
- PyPI: omega-memory