### PR TITLE
Add Fazm - open-source voice-controlled AI agent for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents): An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source browser infrastructure for AI agents with session-backed automation, extraction, screenshots/PDFs, an AI-native CLI, and a reusable steel-browser skill. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)
+
+### Multimodal
+
+- [Fazm](https://github.com/m13v/fazm): Open-source voice-controlled AI agent for macOS that uses accessibility APIs and ScreenCaptureKit to see, understand, and interact with your desktop. ![GitHub Repo stars](https://img.shields.io/github/stars/m13v/fazm?style=social)


### PR DESCRIPTION
Adds [Fazm](https://github.com/m13v/fazm) to the Automation > Desktop section. Open-source, voice-controlled AI computer agent for macOS. Controls your entire desktop through natural language. Built in Swift/SwiftUI, local-first, MIT licensed. https://fazm.ai