### PR TITLE
Add Untether — Telegram bridge for 6 AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
 
 ### Browser
 


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Automation section.

Untether bridges CLI coding agents to Telegram for remote task management. Send tasks by voice or text, watch progress stream in real time, and approve tool calls from your phone.

Supports 6 engines: Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp.

Key features:
- Interactive permission buttons (approve/deny/pause)
- Voice note transcription
- Progress streaming with tool call details
- Cost tracking and budget alerts
- Multi-project support
- Session resume

MIT licensed, Python 3.12+, on PyPI.