### PR TITLE
Add AnveVoice to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Memgpt](https://github.com/cpacker/memgpt): Create LLM agents with long-term memory and custom tools 📚🦙 ![Github Repo stars](https://img.shields.io/github/stars/cpacker/memgpt?style=social)
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
+- [AnveVoice](https://anvevoice.app): AI voice agent for websites — trains on your site, navigates pages, fills forms, books appointments, and talks to visitors in 50+ languages with <700ms latency. One-line embed.
 
 ## Game / Simulation
 


### PR DESCRIPTION
## Summary

- Adds [AnveVoice](https://anvevoice.app) to the **Conversational / General Agents** section
- AnveVoice is an AI voice agent for websites — trains on your site, navigates pages, fills forms, books appointments, and talks to visitors in 50+ languages with <700ms latency. One-line embed.

## Details

- **Category:** Conversational / General Agents
- **Website:** https://anvevoice.app
- Entry follows the existing list format