### PR TITLE
Add Aegis: safety layer for autonomous DeFi agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
+- [Aegis](https://github.com/StanleytheGoat/aegis): Safety layer for autonomous DeFi agents. MCP server that scans contracts against 165 exploit patterns, simulates transactions, and blocks honeypots before agents trade. On-chain enforcement on Base mainnet. ![GitHub Repo stars](https://img.shields.io/github/stars/StanleytheGoat/aegis?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## What is Aegis?

Aegis is a safety layer for autonomous DeFi agents. It runs as an MCP server that scans smart contracts against 165 known exploit patterns, simulates transactions, and blocks honeypots before agents execute trades. It includes on-chain enforcement on Base mainnet.

- GitHub: https://github.com/StanleytheGoat/aegis
- Install: `npx aegis-defi`

## Where is it added?

Added to the **Automation** section, which is the best fit for a tool that protects autonomous agents during on-chain operations.