### PR TITLE
Add Global Chat — cross-protocol AI agent discovery platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [LLocalSearch](https://github.com/nilsherzig/LLocalSearch): LLocalSearch is a completely locally running search aggregator using LLM Agents. The user can ask a question and the system will use a chain of LLMs to find the answer. The user can see the progress of the agents and the final answer. No OpenAI or Google API keys are needed. ![GitHub Repo stars](https://img.shields.io/github/stars/nilsherzig/LLocalSearch?style=social)
 - [Second Brain AI Agent](https://github.com/flepied/second-brain-agent): A streamlit app to dialog with your second brain notes using OpenAI and ChromaDB locally. ![GitHub Repo stars](https://img.shields.io/github/stars/flepied/second-brain-agent?style=social)
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
+- [Global Chat](https://github.com/pumanitro/global-chat): Cross-protocol AI agent discovery platform — searchable directory of 18K+ MCP servers across 6+ registries, with a free agents.txt validator and MCP server for programmatic access. ![GitHub Repo stars](https://img.shields.io/github/stars/pumanitro/global-chat?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Adds [Global Chat](https://github.com/pumanitro/global-chat) to the **Knowledge Management** section.

**Global Chat** is a cross-protocol AI agent discovery platform — a searchable directory of 18K+ MCP servers across 6+ registries, with a free agents.txt validator and an MCP server for programmatic access.

- **Open source**: [github.com/pumanitro/global-chat](https://github.com/pumanitro/global-chat)
- **Published on npm**: [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)
- **Actively maintained**: Regular commits and updates
- **English**: Yes
- **Placement**: Added at the bottom of the Knowledge Management list, per CONTRIBUTING.md guidelines