### PR TITLE
Add OpenClaw agent templates (177 production-ready SOUL.md configs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [OpenClaw Agent Templates](https://github.com/mergisi/awesome-openclaw-agents): 177 production-ready SOUL.md agent configurations for OpenClaw across 24 categories (PM, SEO, DevOps, Writer, Support, and more). Copy-paste ready with tool bindings, memory rules, and heartbeat schedules. Visual deployment via [CrewClaw](https://crewclaw.com). ![GitHub Repo stars](https://img.shields.io/github/stars/mergisi/awesome-openclaw-agents?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## What is this?

Adding [OpenClaw Agent Templates](https://github.com/mergisi/awesome-openclaw-agents) to the Frameworks section.

## Why it belongs here

- **177 production-ready** SOUL.md agent configurations, not toy examples
- **24 categories**: PM, SEO, DevOps, Writer, Support, Sales, Security, Data, and more
- **Copy-paste ready**: Each template includes structured persona definitions, tool bindings, memory rules, and heartbeat schedules
- Built for the [OpenClaw](https://github.com/openclaw/openclaw) agent framework (multi-channel: Telegram, Discord, Slack, WhatsApp)
- Visual deployment available via [CrewClaw](https://crewclaw.com) for one-click setup

The entry matches the existing list format with GitHub stars badge.