### PR TITLE
Add EvalView — regression testing for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [voicetest](https://github.com/voicetestdev/voicetest): Open-source test harness for voice agents with support for Retell, VAPI, Bland, and LiveKit. Run autonomous simulations and evaluate with LLM judges. ![GitHub Repo stars](https://img.shields.io/github/stars/voicetestdev/voicetest?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
+- [EvalView](https://github.com/hidai25/eval-view): Regression testing for AI agents. Snapshot behavior, detect regressions in tool calls and output quality, block broken agents before production. ![GitHub Repo stars](https://img.shields.io/github/stars/hidai25/eval-view?style=social)
 
 ## Software Development
 


### PR DESCRIPTION
Adds [EvalView](https://github.com/hidai25/eval-view) to the Testing and Evaluation section.

EvalView snapshots AI agent behavior (tool calls, parameters, sequence, output), then diffs against baselines after every change. It catches silent regressions — when the agent returns 200 but takes the wrong tool path or degrades output quality.

Key features:
- Golden baseline diffing (tool calls + parameters + output)
- Python API: `gate()` for programmatic checks in autonomous loops
- MCP server with 8 tools for Claude Code integration
- CI/CD with PR comments and Slack alerts
- Multi-turn test support
- LLM-as-judge + deterministic scoring

Published on PyPI (`pip install evalview`), 1126 passing tests, Apache 2.0 license.