### PR TITLE
Add BotVa to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [BotVa](https://github.com/cohe4ko/BotVa): Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination. ![GitHub Repo stars](https://img.shields.io/github/stars/cohe4ko/BotVa?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
## Summary

- Adds [BotVa](https://github.com/cohe4ko/BotVa) to the **Conversational / General Agents** section
- Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination
- MIT licensed, TypeScript

## Details

BotVa is a self-hosted platform for running multiple AI-powered Telegram bots backed by Claude. Key agent capabilities:

- **Multi-bot team coordination**: bots can delegate tasks to each other via a manager bot
- **Persistent semantic memory**: facts, preferences, and episodic memory survive across sessions
- **MCP integration**: each bot connects to multiple MCP servers for tool access (Home Assistant, Google Workspace, CRM, browser automation, etc.)
- **Workspace files**: structured knowledge base and skills system per bot
- **Group chat support**: multiple bots can collaborate in Telegram group conversations with role assignment