### PR TITLE
Add Hashgraph Online (HOL) - Universal agentic registry for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Haystack](https://github.com/deepset-ai/haystack): NLP framework to interact with your data using Transformer models and LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/deepset-ai/haystack?style=social)
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel): Microsoft C# SDK to integrate cutting-edge LLM technology quickly and easily into your apps ![GitHub Repo stars](https://img.shields.io/github/stars/microsoft/semantic-kernel?style=social)
 - [Agent-LLM](https://github.com/Josh-XT/Agent-LLM): An Artificial Intelligence Automation Platform. ![GitHub Repo stars](https://img.shields.io/github/stars/Josh-XT/Agent-LLM?style=social)
+- [Hashgraph Online (HOL)](https://hol.org): Universal agentic registry for AI agents with Universal Agent IDs (UAIDs). Bridges to ERC-8004, A2A, Virtuals, x402. 187K+ verified agents.
 - [LLM Agents](https://github.com/mpaepper/llm_agents): Build agents which are controlled by LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/mpaepper/llm_agents?style=social)
 - [e2b](https://github.com/e2b-dev/e2b): Open-source platform for building & deploying virtual developers’ agents
 - [Dust](https://github.com/dust-tt/dust): Design and Deploy Large Language Model Apps ![GitHub Repo stars](https://img.shields.io/github/stars/dust-tt/dust?style=social)


### PR DESCRIPTION
Adds Hashgraph Online (HOL) - Universal agentic registry for AI agents

- Universal Agent IDs (UAIDs)
- Bridges to ERC-8004, A2A, Virtuals, x402
- 187K+ verified agents