### PR TITLE
Add ShopSavvy MCP Server to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
+- [ShopSavvy MCP Server](https://github.com/shopsavvy/shopsavvy-mcp-server): MCP server giving AI agents real-time product pricing, price history, and shopping tools across 70,000+ retailers. Works with Claude, ChatGPT, Gemini, and any MCP-compatible client. ![GitHub Repo stars](https://img.shields.io/github/stars/shopsavvy/shopsavvy-mcp-server?style=social)
 
 ### Browser
 


### PR DESCRIPTION
we built an open-source MCP server that lets AI agents do product lookups, real-time price comparisons, and price history analysis across 70k+ retailers. works with Claude, ChatGPT, Gemini, Cursor, and anything else that speaks MCP.

repo's at github.com/shopsavvy/shopsavvy-mcp-server — one command to install, free tier with no signup. we've also got SDKs in 10 languages if folks prefer REST.

been doing price comparison since 2008 so the data's solid. added it to the Automation section since it gives agents shopping/pricing superpowers. let me know if you'd want it in a different spot.