### PR TITLE
Add ShopSavvy Desktop to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
+- [ShopSavvy](https://shopsavvy.com/desktop): Autonomous AI shopping agent for Mac, Windows, and Linux — auto-buys at target prices, navigates retailer checkouts, calls stores via voice, and monitors prices in the background.
 
 ### Browser
 


### PR DESCRIPTION
My bad on the last PR, submitted the wrong product. ShopSavvy Desktop is an actual autonomous shopping agent (auto-buys at target prices, navigates checkouts, even calls stores by voice). Added it to the Automation section.