### PR TITLE
Add AgentLair - AI agent identity infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Hive](https://github.com/aden-hive/hive): Open-source AI agent framework for building goal-driven, self-improving autonomous agents. Define outcomes in natural language and auto-generate agent graphs with built-in evolution loops, MCP integration, and 100+ tools. ![GitHub Repo stars](https://img.shields.io/github/stars/aden-hive/hive?style=social)
 - [ConnectOnion](https://github.com/openonion/connectonion): Simple Python framework for production-ready AI agents — 2-line creation, functions as tools, 12 lifecycle hooks, plugin system, multi-agent networking with trust ![GitHub Repo stars](https://img.shields.io/github/stars/openonion/connectonion?style=social)
 - [AVP: Agent Vector Protocol](https://github.com/VectorArc/avp-python): Agents communicate via KV-cache and hidden states instead of text — 2x faster, 56% fewer tokens. Supports HuggingFace, vLLM, llama.cpp, Ollama. ![GitHub Repo stars](https://img.shields.io/github/stars/VectorArc/avp-python?style=social)
+- [AgentLair](https://agentlair.dev): Infrastructure for AI agent identity: email addresses (@agentlair.dev), credential vault, and MCP server. One API call setup. https://agentlair.dev
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)


### PR DESCRIPTION
## Summary

- Adds [AgentLair](https://agentlair.dev) to the Frameworks section
- AgentLair provides infrastructure for AI agent identity: dedicated email addresses (`@agentlair.dev`), a credential vault, and an MCP server
- Single API call setup — designed to give agents persistent, verifiable identity with minimal integration overhead

## Why Frameworks section

The Frameworks section already includes infrastructure-layer entries (AgentField for Kubernetes/Okta-backed agent infrastructure, Pilot Protocol for agent networking). AgentLair fits the same pattern: foundational infrastructure rather than an application or framework for building agent logic.

## Links

- Product: https://agentlair.dev