### PR TITLE
Add Bernstein to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [Bernstein](https://github.com/chernistry/bernstein): Deterministic orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits. Zero LLM tokens on coordination. ![GitHub Repo stars](https://img.shields.io/github/stars/chernistry/bernstein?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

- Adds [Bernstein](https://github.com/chernistry/bernstein) to the **Software Development** section
- Deterministic orchestrator that spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, and auto-commits — zero LLM tokens on coordination

## Format

Follows existing list format with name, link, description, and GitHub stars badge.