### PR TITLE
Add CueAPI to agent infrastructure tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
+- [CueAPI](https://github.com/cueapi/cueapi-core): Open source scheduling and execution accountability API for AI agents. Retries, outcome tracking, and alerts when agents fail silently. ![GitHub Repo stars](https://img.shields.io/github/stars/cueapi/cueapi-core?style=social)
 
 ### Browser
 


### PR DESCRIPTION
CueAPI is an open source scheduling and execution accountability API for AI agents. Retries, outcome tracking, and alerts when agents fail silently.

- Source: https://github.com/cueapi/cueapi-core
- License: Apache 2.0
- Website: https://cueapi.ai