### PR TITLE
Add ClawBox to Automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Automation
 
+- [ClawBox](https://github.com/coderkk1992/clawbox): Run OpenClaw AI agent in a sandboxed Linux VM with native macOS UI. 5-minute setup, no CLI required. ![GitHub Repo stars](https://img.shields.io/github/stars/coderkk1992/clawbox?style=social)
 - [DemoGPT](https://github.com/melih-unsal/DemoGPT): DemoGPT enables you to create quick demos by just using prompt. It applies ToT approach on Langchain documentation tree. ![GitHub Repo stars](https://img.shields.io/github/stars/melih-unsal/DemoGPT?style=social)
 - [RestGPT](https://github.com/Yifan-Song793/RestGPT): An LLM-based autonomous agent controlling real-world applications via RESTful APIs ![GitHub Repo stars](https://img.shields.io/github/stars/Yifan-Song793/RestGPT?style=social)
 - [XAgent](https://github.com/OpenBMB/XAgent): An Autonomous LLM Agent for Complex Task Solving ![GitHub Repo stars](https://img.shields.io/github/stars/OpenBMB/XAgent?style=social)


### PR DESCRIPTION
Adding [ClawBox](https://github.com/coderkk1992/clawbox) to the Automation section.

ClawBox is a native macOS app that runs OpenClaw AI agent in a sandboxed Linux VM. Built with Tauri + React.

- Native macOS UI
- AI runs in isolated VM via Lima
- Supports Claude and GPT
- 5-minute setup, no CLI required
- Drag & drop file sharing

Open source and free.