### PR TITLE
Add Cognitropy Lab — daily auto-generated agent workspaces with entropy engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [Cognitropy Lab](https://github.com/DaxxSec/cognitropy-lab): Autonomous workspace factory — a scheduled Claude agent builds one new Agent Workspace daily using a date-seeded entropy engine with 363 domains, 30 technique modifiers, and crossover days that fuse unrelated fields. Full pipeline from domain assignment to secrets scanning to push. ![GitHub Repo stars](https://img.shields.io/github/stars/DaxxSec/cognitropy-lab?style=social)
 
 ## Research
 


### PR DESCRIPTION
### Cognitropy Lab

[DaxxSec/cognitropy-lab](https://github.com/DaxxSec/cognitropy-lab) — Autonomous daily workspace generator for Claude Code. A scheduled agent builds one new workspace per day using Cognitropy, an entropy engine that hashes the date through five salted SHA-256 passes to select from 363 domains across 22 categories.

Currently at 10 workspaces covering cybersecurity, automotive tuning, environmental science, aquaculture, RF/SDR, and more. Full Agent Workspace Model compliance with slash commands, workflows, and reference materials.

**18.8M unique possible outcomes** — 51,646 years of daily builds before a repeat.

- Open source (MIT)
- Zero human intervention pipeline
- Secrets scanning on every build
- [Agent Workspace Model](https://github.com/danielrosehill/Claude-Agent-Workspace-Model) compliant