### PR TITLE
Add Mission Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
+- [Mission Control](https://github.com/MeisnerDan/mission-control): Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, encrypted vault, and approval workflows. Not a cage. A cockpit. [![GitHub Stars](https://img.shields.io/github/stars/MeisnerDan/mission-control?style=social)](https://github.com/MeisnerDan/mission-control)
 
 ### Browser
 


### PR DESCRIPTION
We're in the middle of an agentic Cambrian explosion. OpenClaw hit 250K stars. Agents are spawning sub-agents, calling APIs, posting content, moving money. The tools to unleash agents are everywhere. The tools to manage them barely exist.

Mission Control fills that gap. Unlike agent frameworks (LangChain, CrewAI, AutoGen) that create agents, Mission Control is where you run them — the cockpit that gives you leverage without flying blind.

Here's the vision: capture an idea in the brain dump, agents research the market, deliver a go/no-go report. You say yes. Agents build the MVP. Field Ops launches it — posting to X, deploying sites, running campaigns — with approval workflows at every step. You made three decisions. They did everything else.

**What makes it different:**
- Autonomous daemon — spawns AI sessions 24/7, loop detection catches stuck agents after 3 failures
- - Field Ops — agents don't just manage tasks, they execute real-world actions through 64 pre-built services
- - Guardrails that let you sleep — encrypted vault (AES-256-GCM), spend limits, circuit breaker, kill switch
- - Token-optimized API — ~50 tokens per request vs ~5,400 unfiltered
317+ stars, 193 tests, 22K+ LOC TypeScript strict. Built by a solo founder who was drowning in agent chaos. Not a cage for your agents. A cockpit.

https://github.com/MeisnerDan/mission-control