### PR TITLE
Add AgentShield — open-source AI agent firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [AgentShield](https://github.com/brigen/agent-shield): Open-source firewall and audit log for AI agents. Intercepts MCP tool calls, CLI commands, and HTTP requests with a policy engine (allow/deny/warn, rate limiting), structured JSON audit logging with secret redaction, and a real-time web dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/brigen/agent-shield?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Description

Adding [AgentShield](https://github.com/brigen/agent-shield) to the **Infrastructure & Governance** section alongside similar tools like Greywall.

AgentShield is an open-source security layer for AI agents that:
- Intercepts MCP tool calls, CLI commands, and HTTP requests between agents and their tools
- Enforces allow/deny/warn policies with rate limiting and regex argument matching
- Provides structured JSON audit logging with automatic secret redaction
- Includes a real-time web dashboard for monitoring agent activity
- Blocks data exfiltration attempts and destructive CLI operations

It's actively maintained, MIT licensed, and installed via npm.
