### PR TITLE
docs: add dograh to conversational agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [Dograh](https://github.com/dograh-hq/dograh): Open-source voice AI platform for building and deploying conversational agents. Drag-and-drop workflow builder, telephony integration (Twilio, Vonage), bring-your-own LLM/TTS/STT, and built-in AI testing with personas. ![GitHub Repo stars](https://img.shields.io/github/stars/dograh-hq/dograh?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
  - Add [Dograh](https://github.com/dograh-hq/dograh) to the Conversational / General Agents section
  - Dograh is an open-source voice AI platform for building and deploying conversational agents with telephony support, drag-and-drop workflows, and bring-your-own LLM/TTS/STT  