### PR TITLE
Add A.S.K. — Agent Skills Kernel to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ConnectOnion](https://github.com/openonion/connectonion): Simple Python framework for production-ready AI agents — 2-line creation, functions as tools, 12 lifecycle hooks, plugin system, multi-agent networking with trust ![GitHub Repo stars](https://img.shields.io/github/stars/openonion/connectonion?style=social)
 - [AVP: Agent Vector Protocol](https://github.com/VectorArc/avp-python): Agents communicate via KV-cache and hidden states instead of text — 2x faster, 56% fewer tokens. Supports HuggingFace, vLLM, llama.cpp, Ollama. ![GitHub Repo stars](https://img.shields.io/github/stars/VectorArc/avp-python?style=social)
 
+- [A.S.K. — Agent Skills Kernel](https://github.com/srmbsrg/ask-kernel): Versioned, composable skill library for AI agents. Define capabilities once in SKILL.md files, invoke by name across sessions. ![GitHub Repo stars](https://img.shields.io/github/stars/srmbsrg/ask-kernel?style=social)
+
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)
 - [Open-RAG-Eval](https://github.com/vectara/open-rag-eval): an open source RAG evaluation framework that does not require golden answers, and can be used to evaluate performance of RAG tools connected to an AI Agent (Agentic RAG)


### PR DESCRIPTION
## What is A.S.K.?

[A.S.K. — Agent Skills Kernel](https://github.com/srmbsrg/ask-kernel) is a versioned, composable skill library for AI agents. Think of it as a shared library for agent capabilities — define skills once in SKILL.md files, invoke by name across sessions.

**Placement:** Added to the Frameworks section at the bottom (per contribution guidelines, placed at bottom of list).

**Why it fits:** ASK provides an agent framework for defining and sharing reusable capabilities, fitting alongside other agent frameworks in this list.