### PR TITLE
Add Signbee MCP to Automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
 - [SwiftAutoGUI](https://github.com/NakaokaRei/SwiftAutoGUI): A Swift library for macOS automation with a built-in AI agent that autonomously observes the screen, reasons, and executes actions using the ReAct pattern. Also provides programmatic mouse, keyboard, screenshot, and image recognition APIs. ![GitHub Repo stars](https://img.shields.io/github/stars/NakaokaRei/SwiftAutoGUI?style=social)
+- [Signbee](https://github.com/nicholasoxford/signbee-mcp): MCP server for agent-driven e-signatures. Send documents for legally binding signing with SHA-256 audit certificates — designed as the signing primitive in autonomous deal-closing workflows.
 
 ### Browser
 


### PR DESCRIPTION
Adds signbee-mcp — an MCP server for agent-driven e-signatures with SHA-256 audit certificates.

Designed as the signing primitive in autonomous deal-closing and contract workflows. Agents can send, track, and verify legally binding signatures via API.

- **npm:** `npx signbee-mcp`
- **Category:** Automation