### PR TITLE
feat: add Claude Code Launchpad (Automated Setup & UX Enhancement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [Claude Code Launchpad](https://github.com/noambrand/kivun-terminal): Windows and macOS installer that transforms Claude Code from a bare CLI into a polished professional suite — automated Node.js, Git, and Claude Code setup, interactive folder selection (skip `cd`), desktop shortcut, and live two-line status bar. ![GitHub Repo stars](https://img.shields.io/github/stars/noambrand/kivun-terminal?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

Submitting Claude Code Launchpad, a professional suite that streamlines the Claude Code experience. It's more than an installer; it adds an interactive folder picker to skip terminal navigation, a customized UI with a status line, and a desktop shortcut for instant access. Ideal for developers wanting a frictionless, 'non-black-screen' workflow.

- Added [Claude Code Launchpad](https://github.com/noambrand/kivun-terminal) to **Software Development**
- Windows and macOS installer: automated Node.js, Git, and Claude Code setup, interactive folder selection (skip `cd`), desktop shortcut, and live two-line status bar

## Test plan
- [x] New entry renders correctly in Software Development
- [x] Link resolves to https://github.com/noambrand/kivun-terminal