### PR TITLE
docs: Add LongTrainer to framework lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Hive](https://github.com/aden-hive/hive): Open-source AI agent framework for building goal-driven, self-improving autonomous agents. Define outcomes in natural language and auto-generate agent graphs with built-in evolution loops, MCP integration, and 100+ tools. ![GitHub Repo stars](https://img.shields.io/github/stars/aden-hive/hive?style=social)
 - [ConnectOnion](https://github.com/openonion/connectonion): Simple Python framework for production-ready AI agents — 2-line creation, functions as tools, 12 lifecycle hooks, plugin system, multi-agent networking with trust ![GitHub Repo stars](https://img.shields.io/github/stars/openonion/connectonion?style=social)
 - [AVP: Agent Vector Protocol](https://github.com/VectorArc/avp-python): Agents communicate via KV-cache and hidden states instead of text — 2x faster, 56% fewer tokens. Supports HuggingFace, vLLM, llama.cpp, Ollama. ![GitHub Repo stars](https://img.shields.io/github/stars/VectorArc/avp-python?style=social)
+- [LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer): A production-ready agentic RAG framework built with LangChain/LangGraph, featuring multi-bot isolation and persistent encrypted memory.
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)


### PR DESCRIPTION
Hi there! 👋

I would like to propose adding **[LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer)** to this awesome list. 

### What is LongTrainer?
LongTrainer is a production-ready framework built on top of LangChain. It allows developers to turn their documents into intelligent, multi-tenant chatbots with just a few lines of code. 

### Why is it a good fit here?
It abstracts away the complexities of manually wiring together chains, memory, tools, and retrievers by offering batteries-included features for production:
- **Multi-bot architecture:** Built-in multi-tenant isolation for managing separate bots effortlessly.
- **Persistent Memory:** Ready-to-use MongoDB-backed, encrypted chat history.
- **Agentic Capabilities:** Supports both standard RAG pipelines and dynamic LangGraph agent tool-calling (web search, custom functions).
- **Extensive Document & Vision Support:** Natively parses PDFs, databases, URLs, and multi-modal images without friction.
- **Streaming:** First-class support for sync and async streaming out of the box.

I believe this will be an extremely valuable, time-saving resource for developers in this community looking to spin up robust GenAI/RAG applications in production quickly.

Thank you for your time and for maintaining this awesome list! Let me know if you need me to adjust the formatting to better fit the repository guidelines. 
