### PR TITLE
Add AutoSearch to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [GenoMAS](https://github.com/Liu-Hy/GenoMAS): A multi-agent framework for scientific discovery that automates gene expression analysis through code-driven workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/Liu-Hy/GenoMAS?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks (data preparation, analysis, modeling, visualization, and insight) and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
+- [AutoSearch](https://github.com/0xmariowu/Autosearch): Self-evolving deep research plugin for Claude Code. 32 dedicated search channels, cross-session learning, cited reports in Markdown/HTML/Slides. ![GitHub Repo stars](https://img.shields.io/github/stars/0xmariowu/Autosearch?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
Added AutoSearch to the bottom of the Research section.

AutoSearch is an open-source, actively maintained self-evolving deep research plugin for Claude Code. It searches 32 dedicated channels in parallel (arXiv, Semantic Scholar, GitHub, Reddit, HN, zhihu, bilibili, and more), evaluates results with LLM scoring, and produces cited reports. It learns which queries and channels work across sessions.

- Repository: https://github.com/0xmariowu/Autosearch
- License: MIT
- Language: Python
- Actively maintained (latest release: April 2026)