### PR TITLE
Add BabelWrap to Browser section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,5 +173,6 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 ### Browser
 
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)
+- [BabelWrap](https://github.com/babelwrap/babelwrap-mcp): HTTP API and MCP server that lets AI agents interact with websites through natural language instead of CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/babelwrap/babelwrap-mcp?style=social)
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents): An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source browser infrastructure for AI agents with session-backed automation, extraction, screenshots/PDFs, an AI-native CLI, and a reusable steel-browser skill. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)


### PR DESCRIPTION
Adds [BabelWrap](https://babelwrap.com) to the Browser section under Automation.

BabelWrap is an HTTP API and MCP server that lets AI agents interact with any website through natural language instead of CSS selectors. 18 MCP tools for navigation, form filling, data extraction, and more.

- **GitHub:** [babelwrap/babelwrap-mcp](https://github.com/babelwrap/babelwrap-mcp)
- **PyPI:** [babelwrap-mcp](https://pypi.org/project/babelwrap-mcp/)
- **Docs:** [babelwrap.com/docs/mcp](https://babelwrap.com/docs/mcp)