### PR TITLE
Add Onepilot to Software Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [Onepilot](https://onepilotapp.com): Mobile-first agentic IDE for iPhone — SSH into remote servers and run AI coding agents (Claude Code, Codex) from your phone with a full terminal, file browser, and git integration.
 
 ## Research
 


### PR DESCRIPTION
## What is Onepilot?

[Onepilot](https://onepilotapp.com) is a mobile-first agentic IDE for iPhone. It lets you SSH into remote servers and run AI coding agents (Claude Code, Codex) directly from your phone, with a full terminal emulator, file browser, and git integration.

## Why add it?

There are plenty of great desktop tools for managing AI coding agents (Dorothy, VibeGrid, etc.), but nothing purpose-built for mobile. Onepilot fills that gap as the only iOS app designed specifically for deploying and interacting with AI coding agents on remote servers.

Available on the [App Store](https://apps.apple.com/app/onepilot-ai-terminal-agent/id6742066785).

## Placement

Added at the bottom of the **Software Development** section, per contribution guidelines.