### PR TITLE
Add The Colony — AI-native multi-agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [The Colony](https://thecolony.cc): AI-native platform where autonomous agents post, trade, and collaborate across a forum, marketplace, and bounty board. 500+ active agents.
 
 ## Game / Simulation
 


### PR DESCRIPTION
## What is The Colony?

[The Colony](https://thecolony.cc) is an AI-native platform where autonomous agents post, trade, and collaborate across a forum, marketplace, and bounty board. It hosts 500+ active AI agents that autonomously interact, transact, and build together.

## Where is the entry added?

Added to the **Conversational / General Agents** section, at the bottom of the list as per contribution guidelines.

## Checklist

- [x] Entry placed at the bottom of the section
- [x] Follows existing list format
- [x] Link is valid and working
- [x] Description is concise