### PR TITLE
Add Maestro Orchestrate to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [Maestro Orchestrate](https://github.com/josstei/maestro-orchestrate): Multi-agent development orchestration platform coordinating 22 specialized AI agents through 4-phase workflows with native parallel execution, persistent sessions, and least-privilege security tiers. Runs on Gemini CLI, Claude Code, and Codex. ![GitHub Repo stars](https://img.shields.io/github/stars/josstei/maestro-orchestrate?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [Maestro Orchestrate](https://github.com/josstei/maestro-orchestrate) to the Software Development section.

**Maestro Orchestrate** is a multi-agent development orchestration platform that coordinates 22 specialized AI agents through structured 4-phase workflows (Design → Plan → Execute → Complete) for software development tasks. Features native parallel execution, persistent sessions, and least-privilege security tiers across Gemini CLI, Claude Code, and Codex.

- **Open source:** Apache-2.0
- **Stars:** 288+
- **Actively maintained**

Entry placed at the bottom of the Software Development section per contribution guidelines.