### PR TITLE
Add SkillClaw — collective skill evolution for OpenClaw-style agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [SkillClaw](https://github.com/AMAP-ML/SkillClaw): Collective skill evolution for OpenClaw-style agents — session-recording client proxy, workflow or OpenClaw-driven evolve servers, shared Skills (`SKILL.md`) synced via OSS/S3/local; documented for PicoClaw, IronClaw, ZeroClaw, NanoClaw, NemoClaw, and related stacks. ![GitHub Repo stars](https://img.shields.io/github/stars/AMAP-ML/SkillClaw?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
## Summary

- Adds [SkillClaw](https://github.com/AMAP-ML/SkillClaw) to the **Conversational / General Agents** section.
- SkillClaw is an open-source Python framework for **collective skill evolution** in multi-user OpenClaw-style setups: a session-recording **client API proxy**, **evolve servers** (fixed LLM workflow or OpenClaw-driven agent), and **shared storage** (Alibaba OSS, S3, or local filesystem) so agent groups can reuse evolved **Skills** (`SKILL.md`) without changing normal assistant usage. Documented integrations include PicoClaw, IronClaw, ZeroClaw, NanoClaw, NemoClaw, and related stacks; includes WildClawBench-oriented experiment tooling and an [arXiv paper](https://arxiv.org/abs/2604.08377). **MIT License.**