### PR TITLE
Add Bitterbot to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [Bitterbot](https://github.com/Bitterbot-AI/bitterbot-desktop): Local-first autonomous agent with biologically-inspired persistent memory — neuromodulator-weighted recall and sleep-cycle consolidation via a "dream" engine — plus a peer-to-peer skills economy. Nodes discover each other over a libp2p gossipsub mesh and trade capabilities via x402. MIT licensed, runs entirely on the user's machine. ![GitHub Repo stars](https://img.shields.io/github/stars/Bitterbot-AI/bitterbot-desktop?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adding Bitterbot to the **Conversational / General Agents** section.

Bitterbot is a local-first autonomous agent built around a biologically-inspired memory system: a neuromodulator-weighted retrieval layer and a "dream" engine that consolidates memories during sleep cycles. Nodes form a libp2p gossipsub mesh so they can discover each other peer-to-peer and trade skills via x402, without any central server.

Why I think it fits the list:

- **Open source**, MIT licensed
- **Actively maintained** — daily commits, independent codebase (not a fork or rebrand)
- Fills a gap in the current section: the memory-focused entries (e.g. MemGPT) don't cover decentralized discovery, and the decentralized entries (e.g. uAgents) don't cover long-horizon biologically-inspired memory. Bitterbot combines both.

I've placed the entry at the bottom of the section per CONTRIBUTING.md. Happy to adjust the category, wording, or formatting if any of it doesn't match house style.
