### PR TITLE
Add BulkPublish — Social Media API with MCP Server for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [Untether](https://github.com/littlebearapps/untether): Telegram bridge for AI coding agents — remote task control with progress streaming, interactive permissions, voice input, and cost tracking. Supports Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. ![GitHub Repo stars](https://img.shields.io/github/stars/littlebearapps/untether?style=social)
 - [SwiftAutoGUI](https://github.com/NakaokaRei/SwiftAutoGUI): A Swift library for macOS automation with a built-in AI agent that autonomously observes the screen, reasons, and executes actions using the ReAct pattern. Also provides programmatic mouse, keyboard, screenshot, and image recognition APIs. ![GitHub Repo stars](https://img.shields.io/github/stars/NakaokaRei/SwiftAutoGUI?style=social)
+- [BulkPublish](https://github.com/azeemkafridi/bulkpublish-api): Social media API for 11 platforms with an MCP server (29 tools) that lets AI agents create posts, schedule content, upload media, and track analytics. REST API, Python & Node.js SDKs. ![GitHub Repo stars](https://img.shields.io/github/stars/azeemkafridi/bulkpublish-api?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## What is BulkPublish?

[BulkPublish](https://github.com/azeemkafridi/bulkpublish-api) is a social media API covering 11 platforms (Facebook, Instagram, X/Twitter, LinkedIn, TikTok, YouTube, Pinterest, Threads, Bluesky, Mastodon, Tumblr).

It is AI-native — the MCP server exposes 29 tools that let AI agents create posts, schedule content, upload media, and track analytics. Also available as a REST API with Python & Node.js SDKs.

- **MCP Server**: https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server
- **npm**: `@bulkpublish/mcp-server`
- **API**: https://app.bulkpublish.com/api

Added to the **Automation** section.