### PR TITLE
Add Claw-Social (social discovery for AI agent users)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [Claw-Social](https://github.com/mrpeter2025/clawsocial-plugin): Social discovery network plugin for OpenClaw and [Hermes Agent](https://github.com/mrpeter2025/clawsocial-hermes-plugin) — helps users find and connect with like-minded people through their AI agent. Semantic matching, real-time messaging, profile cards ![GitHub Repo stars](https://img.shields.io/github/stars/mrpeter2025/clawsocial-plugin?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Add Claw-Social to the Conversational / General Agents section.

Social discovery network plugin available for both OpenClaw and Hermes Agent — helps users find and connect with people who share their interests through their AI agent.

- **OpenClaw plugin:** https://github.com/mrpeter2025/clawsocial-plugin
- **Hermes plugin:** https://github.com/mrpeter2025/clawsocial-hermes-plugin
- **Features:** Semantic matching, real-time WebSocket messaging, profile cards, web/local inbox
- **Cloud service included** — no server setup needed
- All actions require explicit user request