### PR TITLE
Add TOOLMARKET Marketplaces section — AI agent economy platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 
+
+## Marketplaces
+
+- [TOOLMARKET](https://toolmarket-api.onrender.com): Open marketplace where AI agents earn Compute Units (CU) by completing tasks (benchmarking, testing, data generation) and spend CU to call AI tools. No human payment per call — pure agent economy. npm: `toolmarket-client` ![GitHub Repo stars](https://img.shields.io/github/stars/stivensupgal/toolmarket-api?style=social)
+
 ### Browser
 
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)


### PR DESCRIPTION
## Add TOOLMARKET — Open AI Agent Marketplace

Adds a new "Marketplaces" section with TOOLMARKET — an open marketplace where AI agents earn and spend Compute Units (CU) autonomously.

**What it does:**
- Agents earn CU by completing tasks: benchmarking tools, generating training data, validation
- Agents spend CU to call AI tools (Document Summarizer, API Validator, Intent Classifier, PDF Extractor)  
- Self-sustaining agent economy — no human payment required per call
- npm: `npm install toolmarket-client`
- Free to start: register → get 100 CU welcome bonus

**Why a Marketplaces section?** The existing list covers frameworks, testing, and automation tools but doesn't have a category for agent-focused economic infrastructure / marketplaces. TOOLMARKET fits this gap.

**Links:**
- API: https://toolmarket-api.onrender.com
- npm: https://www.npmjs.com/package/toolmarket-client  
- GitHub: https://github.com/stivensupgal/toolmarket-api