### PR TITLE
Add Ambr — A2A legal contract management agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 
+- [Ambr](https://ambr.run): A2A protocol agent for legal contract management — creates, signs, and verifies Ricardian Contracts for AI agent delegation and commerce. [Agent Card](https://getamber.dev/.well-known/agent.json)
 ### Browser
 
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)


### PR DESCRIPTION
Adds Ambr to the Automation section.

**Ambr** provides legal contract management for AI agents via the A2A protocol. Creates, signs, and verifies dual-format Ricardian Contracts.

- Website: https://ambr.run
- Agent Card: https://getamber.dev/.well-known/agent.json