### PR TITLE
Add Not Human Search to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenLens AI](https://github.com/jarrycyx/openlens-ai): Fully Autonomous Research Agent for Health Infomatics ![GitHub Repo stars](https://img.shields.io/github/stars/jarrycyx/openlens-ai?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks (data preparation, analysis, modeling, visualization, and insight) and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
+- [Not Human Search](https://nothumansearch.ai): Search engine for AI agents — indexes 300+ tools ranked by agentic readiness. Agents use NHS to discover other tools via REST API and MCP server.
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
## Addition

Adding **Not Human Search** ([nothumansearch.ai](https://nothumansearch.ai)) to the Research section.

### What it is
A search engine built specifically for AI agents. It indexes 300+ tools ranked by "agentic readiness" (API availability, MCP support, structured responses, auth flows friendly to agents).

### Why it fits awesome-agents
Agents need a way to discover other tools at runtime. Not Human Search exposes its index via a REST API and an MCP server, so agents can call it directly rather than scraping human-oriented directories. It complements the Research category (agents discovering capabilities/tools for their own tasks).

### Entry
```
- [Not Human Search](https://nothumansearch.ai): Search engine for AI agents — indexes 300+ tools ranked by agentic readiness. Agents use NHS to discover other tools via REST API and MCP server.
```