### PR TITLE
Add Not Human Search to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Second Brain AI Agent](https://github.com/flepied/second-brain-agent): A streamlit app to dialog with your second brain notes using OpenAI and ChromaDB locally. ![GitHub Repo stars](https://img.shields.io/github/stars/flepied/second-brain-agent?style=social)
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
 - [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, MCP, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)
+- [Not Human Search](https://nothumansearch.ai): Search engine built for AI agents — indexes 1,100+ agent-ready tools and APIs ranked by agentic readiness (0-100 score based on llms.txt, OpenAPI spec, MCP server, structured API, ai-plugin). Available as an MCP server, REST API, and OpenAPI spec so agents can discover tools programmatically.
 
 ## Automation
 


### PR DESCRIPTION
## Summary

Adds [Not Human Search](https://nothumansearch.ai) to the Knowledge Management section.

Not Human Search is a search engine built for AI agents. It indexes 1,100+ agent-ready tools and APIs, scoring each site 0–100 based on agentic readiness signals (llms.txt, OpenAPI spec, MCP server, structured API, ai-plugin.json).

**Key features:**
- **MCP server** — published in the official MCP registry (`ai.nothumansearch/search`), so agents can discover tools natively
- **REST API + OpenAPI spec** — programmatic access for any HTTP client
- **Agentic readiness scoring** — transparent 0–100 score based on machine-readable signals
- **Categories** — developer, data, AI/ML, communication, productivity, and more

**Why Knowledge Management:** NHS helps agents find and evaluate tools — it's a discovery/knowledge layer analogous to LLocalSearch and other entries in this section.

Placed at the bottom of the section per contribution guidelines.