### PR TITLE
Add LlmSandbox and LLM-Sim-Alpha to Agent Society Simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Camel-AutoGPT](https://github.com/SamurAIGPT/Camel-AutoGPT): role-playing approach for LLMs and auto-agents like BabyAGI & AutoGPT ![GitHub Repo stars](https://img.shields.io/github/stars/SamurAIGPT/Camel-AutoGPT?style=social)
 - [SkyAGI](https://github.com/litanlitudan/skyagi): Emerging human-behavior simulation capability in LLM agents ![GitHub Repo stars](https://img.shields.io/github/stars/litanlitudan/skyagi?style=social)
 - [Voyager](https://github.com/MineDojo/Voyager): An Open-Ended Embodied Agent with Large Language Models ![GitHub Repo stars](https://img.shields.io/github/stars/MineDojo/Voyager?style=social)
+* [LlmSandbox](https://github.com/Trainerx7979/LlmSandbox) - Real-time 2D NPC sandbox where procedurally generated agents live, move, and make decisions via local LLM (Ollama/LM Studio). Features memory, relationships, goal-setting, and a developer console for injecting commands.
+* [LLM-Sim-Alpha](https://github.com/Trainerx7979/LLM-Sim-Alpha) - Research-oriented emergent-behavior simulation where one NPC is secretly evil. Full JSONL logging of every agent brain state, visual log replay viewer, and configurable storyteller alignments. Built for studying emergent social dynamics.
 
 ## Knowledge Management
 


### PR DESCRIPTION
## What's being added

Two open-source, locally-running LLM agent simulation tools:

**LlmSandbox** (https://github.com/Trainerx7979/LlmSandbox)   A real-time 2D NPC sandbox where agents make live LLM-powered decisions, form memories and relationships, and respond to world events. Runs on Ollama or LM Studio. Includes a developer console for injecting natural language commands. MIT licensed.

**LLM-Sim-Alpha** (https://github.com/Trainerx7979/LLM-Sim-Alpha)   A research-oriented predecessor focused on emergent social behavior — one NPC is secretly evil and tries to eliminate the others. Every turn logs full agent brain states (mood, memory, suspicions, monologue, relationships). Includes a visual log replay viewer for post-hoc analysis. Configurable storyteller with alignments (neutral/benevolent/malevolent/chaotic/scientific). MIT licensed.

## Why these fit
Both tools are open-source, run fully locally, and sit squarely in the agent social simulation space alongside existing entries like generative_agents, ai-town, and GPTeam — with the distinction that they run on consumer hardware via Ollama rather than requiring cloud APIs.