### PR TITLE
Add semantix-ai under Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 * [traceAI](https://github.com/future-agi/traceAI): Open-source OpenTelemetry-native tracing framework that auto-instruments 20+ AI frameworks and LLM providers (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Bedrock) capturing prompts, tokens, latency, and errors out of the box. [![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/traceAI?style=social)](https://github.com/future-agi/traceAI)
+- [semantix-ai](https://github.com/labrat-akhona/semantix-ai): Local, deterministic semantic validation of agent outputs via a quantized NLI model. Catches policy violations, handles negated intents (e.g., "must NOT give medical advice"), and emits a tamper-evident hash-chained audit trail. Zero API cost, ~15 ms per check. ![GitHub Repo stars](https://img.shields.io/github/stars/labrat-akhona/semantix-ai?style=social)
 
 ## Software Development
 


### PR DESCRIPTION
Adds semantix-ai under Testing and Evaluation.

semantix-ai is an open-source (MIT) Python library for validating AI agent outputs against plain-English intents using a local quantized NLI model (~25 MB ONNX, ~15 ms per call, deterministic, no API key).

Why it fits this list:
- Dedicated tooling for testing agent outputs — drop-in reward/metric for DSPy, pytest assertions, validators for LangChain/Pydantic-AI/Guardrails/Instructor.
- Handles negated intents ("must NOT give medical advice", "must NOT disclose PII") — useful for policy enforcement in agent loops.
- Every validation emits a hash-chained JSON-LD audit certificate. Tamper-evident — relevant for compliance-sensitive agent workflows.
- Also ships an MCP server (`semantix.mcp.server`) so any MCP-capable agent (Claude Desktop, Cursor, etc.) can call `verify_text_intent` as a tool.

- Repo: https://github.com/labrat-akhona/semantix-ai
- PyPI: https://pypi.org/project/semantix-ai/
- Docs: https://labrat-akhona.github.io/semantix-ai/
- License: MIT
