### PR TITLE
Add Caesar to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenLens AI](https://github.com/jarrycyx/openlens-ai): Fully Autonomous Research Agent for Health Infomatics ![GitHub Repo stars](https://img.shields.io/github/stars/jarrycyx/openlens-ai?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks (data preparation, analysis, modeling, visualization, and insight) and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
+- [Caesar](https://github.com/jasonzliang/caesar-agent): autonomous research agent with graph-based deep web exploration and adversarial answer synthesis (Generator-Verifier loop). Published paper ([Liang et al., 2026](https://doi.org/10.13140/RG.2.2.15118.22088)) shows it outperforms ChatGPT / Gemini Deep Research on creative reasoning benchmarks (p<0.001). ![GitHub Repo stars](https://img.shields.io/github/stars/jasonzliang/caesar-agent?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
Adding [Caesar](https://github.com/jasonzliang/caesar-agent) to the Research section, placed right after AIDE.

Caesar is an autonomous research agent built around two ideas. A Perceive-Think-Act loop builds a knowledge graph during web traversal, and an adversarial Generator-Verifier loop then refines multiple drafts by generating orthogonal queries that target weaknesses in the previous draft before a generative merge. It's in the same neighborhood as GPT Researcher and Storm, but the graph construction during exploration and the adversarial refinement step are the main differences from standard single-pass RAG research pipelines.

The approach is from a paper we published in March ([Liang, Meyerson, Miikkulainen 2026](https://doi.org/10.13140/RG.2.2.15118.22088), Cognizant AI Lab). In a blinded 3-model LLM-as-a-Judge evaluation on creative reasoning, Caesar scored 25.29 / 30 vs. Gemini 3 Deep Research (22.27) and ChatGPT / GPT-5.2 Deep Research (15.40), p<0.001 across all conditions.

v0.3.0 released April 19, Python 3.10+, MIT licensed, multi-provider via litellm. Happy to tighten the description if it's longer than you'd like.