### PR TITLE
Add BenchGecko Agent Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,4 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents): An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source browser infrastructure for AI agents with session-backed automation, extraction, screenshots/PDFs, an AI-native CLI, and a reusable steel-browser skill. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)
 - [Actionbook](https://github.com/actionbook/actionbook): Parallel Action CLI for AI agents. Run 50 actions across 20 sites at onece. ![GitHub Repo stars](https://img.shields.io/github/stars/actionbook/actionbook?style=social)
+- [BenchGecko Agents](https://benchgecko.ai/agents) - AI agent leaderboard with SWE-bench, GAIA, OSWorld, and tau-bench scores. 165 agents tracked.


### PR DESCRIPTION
Adds BenchGecko's agent leaderboard as a testing and evaluation resource.

Tracks 165 AI agents with capability scores across real-world evaluation benchmarks.

https://benchgecko.ai/agents