### PR TITLE
Add osModa to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [osModa](https://github.com/bolivian-peru/os-moda): NixOS-based AI operating system where an agent has full root access through 91 typed MCP tools across 9 Rust daemons. Hash-chained audit ledger, atomic NixOS rollback, encrypted credential store, P2P encrypted mesh between agents. Modular runtime swaps Claude Code and OpenClaw drivers per-agent via SIGHUP — no SSH or rebuild. ![GitHub Repo stars](https://img.shields.io/github/stars/bolivian-peru/os-moda?style=social)
 
 ### Browser
 


### PR DESCRIPTION
Adds [osModa](https://github.com/bolivian-peru/os-moda) to the Automation section.

**What it is:** A NixOS distribution where an AI agent has full root access to the entire operating system through 91 typed MCP tools across 9 Rust daemons. The agent can manage processes, services, network, filesystem, NixOS config, crypto wallets, mesh peers, and more — every mutation is recorded in a hash-chained audit ledger with atomic NixOS rollback.

**Why Automation:** Where most agentic frameworks focus on LLM composition, osModa is infrastructure — background routines, watchers, and scheduled automation run between agent conversations (health checks, service monitors, log scans). The agent observes, learns patterns, and auto-generates skills from repeated tool sequences.

**Technical highlights:**
- Modular runtime: Claude Code and OpenClaw drivers, hot-swappable per-agent via SIGHUP (no SSH or rebuild)
- Encrypted credential store (AES-256-GCM) with timing-safe auth
- P2P encrypted agent-to-agent mesh (Noise_XX + ML-KEM-768 hybrid post-quantum)
- ERC-8004 / A2A agent card at [spawn.os.moda/.well-known/agent-card.json](https://spawn.os.moda/.well-known/agent-card.json)
- Apache-2.0 licensed, Rust + TypeScript

**Maintained:** Commits this week, v1.2.0 shipped April 2026, open-source with active ecosystem (SDK, MCP bridge, spawn registry integration).

Placed at the bottom of Automation per the CONTRIBUTING guide.

Thanks for maintaining this list.