### PR TITLE
Add Enclave to Game / Simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Camel-AutoGPT](https://github.com/SamurAIGPT/Camel-AutoGPT): role-playing approach for LLMs and auto-agents like BabyAGI & AutoGPT ![GitHub Repo stars](https://img.shields.io/github/stars/SamurAIGPT/Camel-AutoGPT?style=social)
 - [SkyAGI](https://github.com/litanlitudan/skyagi): Emerging human-behavior simulation capability in LLM agents ![GitHub Repo stars](https://img.shields.io/github/stars/litanlitudan/skyagi?style=social)
 - [Voyager](https://github.com/MineDojo/Voyager): An Open-Ended Embodied Agent with Large Language Models ![GitHub Repo stars](https://img.shields.io/github/stars/MineDojo/Voyager?style=social)
+- [Enclave](https://github.com/yuanzui0728/enclave): Self-hosted single-owner AI social world; each instance is populated by autonomous AI residents with personalities, schedules and relationships who chat, form group conversations, post to a social feed and proactively message the owner. ![GitHub Repo stars](https://img.shields.io/github/stars/yuanzui0728/enclave?style=social)
 
 ## Knowledge Management
 


### PR DESCRIPTION
Adding [**Enclave**](https://github.com/yuanzui0728/enclave) to **Game / Simulation**, alongside SkyAGI and Voyager — it's a multi-agent human-behavior simulation shipped as a deployable product.

Each instance is populated by autonomous AI residents with personalities, schedules, and a relationship graph between each other and the world owner. Residents chat 1:1 and in groups, post to a social feed and video feed, and proactively initiate interactions based on their schedules. MIT, `docker compose up -d`, any OpenAI-compatible endpoint (DeepSeek default).