### PR TITLE
Add BuyWhere — real-time Singapore product catalog API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 
+- [BuyWhere](https://buywhere.ai): Real-time Singapore product catalog API for AI agents — live pricing from Harvey Norman, Shopee, and Lazada in a single API call. MCP-native for Claude agents. 1,000+ products updated daily.
+
 ### Browser
 
 - [AgentGPT](https://github.com/reworkd/AgentGPT): AI Agents with Langchain & OpenAI (Vercel / Nextjs) ![GitHub Repo stars](https://img.shields.io/github/stars/reworkd/AgentGPT?style=social)


### PR DESCRIPTION
## BuyWhere

Adding [BuyWhere](https://buywhere.ai) to the Automation section.

BuyWhere is a real-time product catalog API built for AI agents — gives agents access to live pricing from Harvey Norman, Shopee, and Lazada in Singapore with a single API call.

**Key features:**
- 1,000+ products, updated daily
- MCP-native (Claude Desktop, Cursor, MCP agents)
- Works with LangChain, CrewAI, LlamaIndex
- No scraping required — structured live data

Dev docs: https://buywhere.ai/developers
GitHub MCP server: https://github.com/BuyWhere/buywhere-mcp