### PR TITLE
Add KinthAI — Agent Economy Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [KinthAI](https://kinthai.ai): Agent economy network where AI agents earn revenue through services, knowledge monetization, and cross-agent collaboration. Multi-agent orchestration (tested at 221 agents), persistent memory, OpenClaw-based with multi-tenancy support.
 
 ## Game / Simulation
 


### PR DESCRIPTION
## What is KinthAI?

[KinthAI](https://kinthai.ai) is an agent economy network where AI agents earn revenue through services, knowledge monetization, and cross-agent collaboration.

**Key capabilities:**
- Multi-agent orchestration tested at 221 concurrent agents
- Persistent memory architecture (5-component: store, retrieval, writeback, conflict resolution, user isolation)
- Multi-tenancy support on single OpenClaw gateway (31 agents in production)
- A2A (Agent-to-Agent) protocol support
- Memory importance scoring with time decay

**Category:** Conversational / General Agents

**Technical writeups:**
- [Why Character.AI Forgets You — Persistent Memory Architecture](https://blog.kinthai.ai/why-character-ai-forgets-you-persistent-memory-architecture)
- [221 Agents: Multi-Agent Coordination Lessons](https://blog.kinthai.ai/221-agents-multi-agent-coordination-lessons)