### PR TITLE
Add lean-ctx to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [amux](https://github.com/mixpeek/amux): Open-source agent multiplexer for running dozens of parallel Claude Code sessions with a web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA. Python 3 + tmux. ![GitHub Repo stars](https://img.shields.io/github/stars/mixpeek/amux?style=social)
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, multi-agent collaboration via channels and pod bindings, built-in Kanban with MR/PR integration. ![GitHub Repo stars](https://img.shields.io/github/stars/AgentsMesh/AgentsMesh?style=social)
 - [KubeStellar Console](https://github.com/kubestellar/console): Multi-cluster Kubernetes dashboard with AI-powered operations agent (kc-agent) providing MCP tools for managing workloads across edge and cloud clusters. CNCF project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
+- [lean-ctx](https://github.com/yvgude/lean-ctx): Open-source context runtime for AI coding agents. MCP server + shell hook reducing token costs by 60-99%. 46 tools, session caching, AST-aware compression. Single Rust binary. Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/yvgude/lean-ctx?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [lean-ctx](https://github.com/yvgude/lean-ctx) to the Software Development section.

**lean-ctx** is an open-source context runtime for AI coding agents: MCP server and shell hook that reduce token costs (session caching, AST-aware compression, 46 tools). Single Rust binary, Apache-2.0.

- Website: https://leanctx.com

Made with [Cursor](https://cursor.com)