### PR TITLE
Add Caesar to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenLens AI](https://github.com/jarrycyx/openlens-ai): Fully Autonomous Research Agent for Health Infomatics ![GitHub Repo stars](https://img.shields.io/github/stars/jarrycyx/openlens-ai?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks (data preparation, analysis, modeling, visualization, and insight) and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
+- [Caesar](https://github.com/jasonzliang/caesar-agent): Autonomous research agent that builds a knowledge graph during web exploration via a Perceive-Think-Act loop, then refines drafts through a Generator-Verifier loop with adversarial query synthesis. Multi-provider via litellm. ![GitHub Repo stars](https://img.shields.io/github/stars/jasonzliang/caesar-agent?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
**PR Summary:** 

Adding [Caesar](https://github.com/jasonzliang/caesar-agent) to the Research section, placed at the bottom after AIDE.

Caesar is an open-source autonomous research agent built around two ideas:
- A **Perceive-Think-Act loop** that builds a knowledge graph during web traversal.
- A **Generator-Verifier loop** that refines drafts by generating orthogonal queries targeting weaknesses in the previous draft, then merges them.

Same neighborhood as GPT Researcher and Storm (already listed), but the graph construction during exploration and the adversarial refinement step are the differences from standard single-pass RAG research pipelines.

**Note:** 

This is a resubmission of #403, that PR was auto-closed by the bot. I have re-read through the contribution rules and tightened the description to match the format of other entries (no comparative/benchmark claims) and put the entry at the bottom of the Research section.