### PR TITLE
Add MateClaw to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels (DingTalk, Feishu, WeChat Work, WeChat, Telegram, Discord, QQ, Slack) sharing the same agent. ReAct + Plan-and-Execute on a StateGraph runtime, multi-vendor failover with health tracking, LLM Wiki with per-sentence citations, memory lifecycle, MCP, Tool Guard. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
## Summary

Adds **MateClaw** to the **Conversational / General Agents** section, placed at the bottom per `CONTRIBUTING.md`.

## How it meets the contribution criteria

- **Open source**: Apache 2.0 ([LICENSE](https://github.com/matevip/mateclaw/blob/main/LICENSE)).
- **Demonstrated traction**: 363 stars, 116 forks, 137 published releases since 2026-04-04, active daily commits.
- **Maintained**: Last push 2026-05-01. CHANGELOG and release artifacts shipping continuously (Mac/Win/Linux desktop installers, Docker images).
- **Online**: Repo, docs site (https://claw.mate.vip/docs), live demo (https://claw-demo.mate.vip).
- **English**: README and documentation are bilingual (English + Simplified Chinese); English is primary.
- **Agentic**: ReAct + Plan-and-Execute agents implemented as nodes/edges on Spring AI Alibaba's StateGraph runtime; tool-using agents with an approval-gated Tool Guard layer.
- **Adds value vs existing entries**: This is the first Java/Spring Boot personal AI agent platform on the list, complementary to the Python/TS-heavy lineup. Adds a multi-vendor failover angle (provider chain with health tracker + cooldown) that none of the current Conversational agents cover.

## What was added

One bullet appended at the **bottom** of `## Conversational / General Agents`, following the repo's `[Name](URL): description ![stars-badge]` format.

## Links

- Repo: https://github.com/matevip/mateclaw
- Documentation: https://claw.mate.vip/docs
- Live demo: https://claw-demo.mate.vip
- Releases: https://github.com/matevip/mateclaw/releases