### PR TITLE
Add AgentMinds to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 * [traceAI](https://github.com/future-agi/traceAI): Open-source OpenTelemetry-native tracing framework that auto-instruments 20+ AI frameworks and LLM providers (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Bedrock) capturing prompts, tokens, latency, and errors out of the box. [![GitHub Repo stars](https://img.shields.io/github/stars/future-agi/traceAI?style=social)](https://github.com/future-agi/traceAI)
+- [AgentMinds](https://github.com/agentmindsdev/python-sdk): Cross-site collective intelligence pool for production AI agents. Sentry-style auto-capture + push agent reports / pull personalised recommendations from a network pool of solved patterns. Python + Node SDKs, ARP 1.1 spec, MCP-aware. ![GitHub Repo stars](https://img.shields.io/github/stars/agentmindsdev/python-sdk?style=social)
 
 ## Software Development
 


### PR DESCRIPTION
## What this adds

[AgentMinds](https://github.com/agentmindsdev/python-sdk) — a cross-site collective intelligence pool for production AI agents.

- Sentry-style runtime auto-capture (uncaught exceptions, 5xx, ERROR logs).
- Open `agent_report` envelope ([AgentMinds Reporting Profile / ARP v1.1](https://github.com/agentmindsdev/profile)) for richer agent telemetry — metrics, learned_patterns, warnings.
- Pull side: connected sites get back personalised, ranked recommendations + benchmarks vs the network — solved patterns from peer sites running similar stacks. SDK exposes `agentminds.sync.report()` / `.recommendations()` / `.benchmarks()` / `.networkPosition()`.

Sits alongside Arize-Phoenix, Manifest, and traceAI in the Testing / Evaluation / Observability shelf with the additional cross-site recommendation surface.

## Production status

- Python SDK: [`agentminds`](https://pypi.org/project/agentminds/) v0.5.0 on PyPI, MIT.
- Node SDK: [`@agentmindsdev/node`](https://www.npmjs.com/package/@agentmindsdev/node) v0.4.0 on npm, MIT.
- Spec: [`agentmindsdev/profile`](https://github.com/agentmindsdev/profile) — ARP v1.1 published.
- MCP-aware (engaging with the MCP extensions-wg).

Happy to move sections / re-word if a different home fits better.