### PR TITLE
Add Web Agent Bridge (WAB) - open protocol for AI agent-website interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🤖 Awesome Agents
+﻿# 🤖 Awesome Agents
 
 Awesome Agents is a curated list of open-source tools and products to build AI agents.
 
@@ -178,3 +178,5 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenAgents](https://github.com/xlang-ai/OpenAgents): An Open Platform for Language Agents in the Wild ![GitHub Repo stars](https://img.shields.io/github/stars/xlang-ai/OpenAgents?style=social)
 - [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source browser infrastructure for AI agents with session-backed automation, extraction, screenshots/PDFs, an AI-native CLI, and a reusable steel-browser skill. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)
 - [Actionbook](https://github.com/actionbook/actionbook): Parallel Action CLI for AI agents. Run 50 actions across 20 sites at onece. ![GitHub Repo stars](https://img.shields.io/github/stars/actionbook/actionbook?style=social)
+- [Web Agent Bridge (WAB)](https://github.com/abokenan444/web-agent-bridge) — Open protocol that gives AI agents a standardized `window.AICommands` interface on any website. Includes DNS Discovery with Ed25519 cryptographic trust (DNSSEC), MCP adapter (`@wab/mcp-server`) for Claude/GPT/LangChain, Dynamic Pricing Shield for non-WAB sites, WordPress mu-plugin, and one-click deploy to Cloudflare/Vercel/Netlify/Railway.
+


### PR DESCRIPTION
## What is WAB?

Web Agent Bridge is an open protocol that standardizes how AI agents interact with websites — replacing per-site custom browser automation with a unified `window.AICommands` interface.

Think of it as: **robots.txt told bots what NOT to do. WAB tells AI agents what they CAN do.**

## Why it belongs here

- Solves a real problem: every agent builder today writes custom DOM scraping per site — WAB eliminates this
- MCP-native: ships with `@wab/mcp-server` for Claude/GPT/LangChain
- DNS Discovery: `_wab TXT record` makes sites auto-discoverable by AI agents
- Cryptographic trust: Ed25519 + DNSSEC — no central CA needed
- WordPress mu-plugin: instant deployment on 43% of the internet
- Dynamic Pricing Shield: works on non-WAB sites too via multi-identity price probing
- Open Core, MIT license, actively maintained (180+ commits, Netherlands-based)

## Links
- GitHub: https://github.com/abokenan444/web-agent-bridge
- npm: https://www.npmjs.com/package/web-agent-bridge
- MCP: https://www.npmjs.com/package/@wab/mcp-server
- Site: https://webagentbridge.com
