### PR TITLE
Add OpenAgent to Conversational / General Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [joinly](https://github.com/joinly-ai/joinly): Voice-first AI Assistant for online meetings that can actively participate and solve tasks live during the meeting ![GitHub Repo stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)
 - [Gobii](https://github.com/gobii-ai/gobii-platform): Gobii is an open-source platform for deploying and managing browser-use agents at scale with a conversational interface and API ![GitHub Repo stars](https://img.shields.io/github/stars/gobii-ai/gobii-platform?style=social)
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
+- [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Add OpenAgent to Conversational / General Agents section

**Project:** [OpenAgent](https://github.com/the-open-agent/openagent)
**Stars:** 4,531 | **Forks:** 536 | **License:** Apache-2.0

**Description:**
OpenAgent is a next-generation personal AI assistant powered by LLM, RAG and agent loops. It supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. It is self-hostable with a built-in admin dashboard.

**Why it fits awesome-agents:**
- Mature, actively maintained open-source project (created 2020, last updated May 2026)
- Strong community traction with 4,531+ stars and 536 forks
- Comprehensive agent capabilities: autonomous agent loops, RAG knowledge base, browser automation, shell execution, office automation, MCP integration
- Multi-tenant platform with SSO, REST API, audit logs, and usage analytics
- Online demo available at https://demo.openagentai.org

Added at the bottom of the Conversational / General Agents section as per contribution guidelines.