### PR TITLE
Add TweetClaw to Automation agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
 - [osModa](https://github.com/bolivian-peru/os-moda): Your server fixes itself at 3am. You sleep. AI-native operating system built on NixOS. ![GitHub Repo stars](https://img.shields.io/github/stars/bolivian-peru/os-moda?style=social)
+- [TweetClaw](https://github.com/Xquik-dev/tweetclaw): OpenClaw plugin for X/Twitter automation with 99 agent-callable endpoints, explicit approval boundaries, and pay-per-use read mode. ![GitHub Repo stars](https://img.shields.io/github/stars/Xquik-dev/tweetclaw?style=social)
 
 ### Browser
 


### PR DESCRIPTION
## Summary

- Adds TweetClaw to the Automation section.
- Keeps the entry in the existing one-line format with a GitHub stars badge.

## Fit

- TweetClaw is an MIT-licensed OpenClaw plugin for X/Twitter automation.
- It is maintained, published on npm, and exposes 99 agent-callable endpoints through structured OpenClaw tools.
- The entry is placed at the bottom of the list, per the contribution guidelines.
