### PR TITLE
Add ejentum/ejentum-mcp under Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Frameworks
 
+- [ejentum/ejentum-mcp](https://github.com/ejentum/ejentum-mcp): Reasoning Harness for agentic AI exposed as 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, catching sycophancy, hallucination, and reasoning decay before they emerge in long agent loops. ![GitHub Repo stars](https://img.shields.io/github/stars/ejentum/ejentum-mcp?style=social)
 - [OpenClaw](https://github.com/openclaw/openclaw): Open-source AI agent framework that turns LLMs into persistent, proactive personal AI agents with multi-channel messaging (Signal, Telegram, Discord, WhatsApp), cron scheduling, memory systems, MCP integration, skill plugins, sub-agent spawning, and browser automation. ![GitHub Repo stars](https://img.shields.io/github/stars/openclaw/openclaw?style=social)
 - [Hermes Agent](https://github.com/nousresearch/hermes-agent): The agent that grows with you 
 - [llama-agentic-system](https://github.com/meta-llama/llama-agentic-system): Agentic components of the Llama Stack APIs ![GitHub Repo stars](https://img.shields.io/github/stars/meta-llama/llama-agentic-system?style=social)


### PR DESCRIPTION
Adding **ejentum-mcp**, an MCP server exposing the Reasoning Harness as four cognitive operating modes (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, addressing the four mechanism failures common in production agent loops: attention decay, reasoning decay, sycophantic collapse, hallucination drift.

Placement: Frameworks. The category description fits MCP-server infrastructure that any LLM agent calls per turn; sits alongside OpenClaw, LangChain, AG2 etc. as agent infrastructure.

Links:
- Source: https://github.com/ejentum/ejentum-mcp (MIT)
- npm: https://www.npmjs.com/package/ejentum-mcp
- Official MCP Registry: io.github.ejentum/ejentum-mcp
- Glama, mcp.so, Smithery, Continue Hub listed
- Free tier: 100 calls

Disclosure: I'm the maintainer.