### PR TITLE
Add Prismfy Wizard: install live web search rules into local AI agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Software Development
 
+- [Prismfy Wizard](https://github.com/prismfy/prismfy-wizard) — CLI that installs persistent live web search rules into local AI agent workflows by adding a `prismfy-search` command and managed search-policy blocks to agent instruction files.
 - [MetaGPT](https://github.com/geekan/MetaGPT): The Multi-Agent Framework: First AI Software Company, Towards Natural Language Programming ![GitHub Repo stars](https://img.shields.io/github/stars/geekan/MetaGPT?style=social)
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands): 🙌 OpenHands: Code Less, Make More. (formerly OpenDevin), a platform for software development agents powered by AI ![GitHub Repo stars](https://img.shields.io/github/stars/All-Hands-AI/OpenHands?style=social)
 - [GPT Pilot](https://github.com/Pythagora-io/gpt-pilot): GPT Pilot is the core technology for the Pythagora VS Code extension that aims to provide the first real AI developer companion. ![GitHub Repo stars](https://img.shields.io/github/stars/Pythagora-io/gpt-pilot?style=social)


### PR DESCRIPTION
## What I'm adding

I'd like to add [Prismfy Wizard](https://github.com/prismfy/prismfy-wizard), an open-source CLI for local AI agent workflows.

It installs:
- a local `prismfy-search` command
- managed search-policy blocks in agent instruction files
- selectable verification modes (`minimal`, `balanced`, `research`, `strict`)

This helps coding and research agents verify current external facts instead of relying only on model memory.

## Suggested entry

- [Prismfy Wizard](https://github.com/prismfy/prismfy-wizard) — CLI that installs persistent live web search rules into local AI agent workflows by adding a `prismfy-search` command and managed search-policy blocks to agent instruction files.
