### PR TITLE
Add AgentPlane — Git-native workflow control plane for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [amux](https://github.com/mixpeek/amux): Open-source agent multiplexer for running dozens of parallel Claude Code sessions with a web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA. Python 3 + tmux. ![GitHub Repo stars](https://img.shields.io/github/stars/mixpeek/amux?style=social)
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, multi-agent collaboration via channels and pod bindings, built-in Kanban with MR/PR integration. ![GitHub Repo stars](https://img.shields.io/github/stars/AgentsMesh/AgentsMesh?style=social)
 - [KubeStellar Console](https://github.com/kubestellar/console): Multi-cluster Kubernetes dashboard with AI-powered operations agent (kc-agent) providing MCP tools for managing workloads across edge and cloud clusters. CNCF project. ![GitHub Repo stars](https://img.shields.io/github/stars/kubestellar/console?style=social)
+- [AgentPlane](https://github.com/basilisk-labs/agentplane): Git-native audit layer for coding-agent work. Records task intent, approved plans, verification evidence, finish state, and Agent Change Records inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/basilisk-labs/agentplane?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

Adds [AgentPlane](https://github.com/basilisk-labs/agentplane) to the **Frameworks** section.

AgentPlane is a Git-native workflow control plane for AI coding agents. It keeps task intent, approved plans, verification evidence, finish state, and Agent Change Records inside the repository for Claude Code, Codex, Cursor, Aider, and similar tools.

- **Homepage**: https://agentplane.org
- **License**: MIT
- **Only README.md was modified** (one bullet point added to the Frameworks section)

Disclosure: I maintain AgentPlane.

I moved this from Software Development to Frameworks because accepted/reviewed entries such as Cordum are framed there as governance/control-plane infrastructure for agents.
