### PR TITLE
Add Dakera to Knowledge Management — self-hosted MCP agent memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
 - [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, MCP, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)
 - [Screenpipe](https://github.com/screenpipe/screenpipe): 24/7 local screen + microphone recording with OCR, audio transcription, and semantic search. Gives AI agents long-term context of everything you've seen, said, or heard. MCP server for Claude. 100% local, MIT licensed. ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social)
+- [Dakera](https://github.com/dakera-ai/dakera-mcp): Self-hosted MCP-native agent memory server with decay-weighted recall, HNSW vector search, and cross-agent knowledge sharing. Production-ready, written in Rust, self-deployable. ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## Description

Adding **[Dakera](https://github.com/dakera-ai/dakera-mcp)** to the Knowledge Management section.

Dakera is a self-hosted, MCP-native agent memory server designed for AI agent workflows:
- **Decay-weighted recall**: memories are scored by recency, importance, and access frequency
- **HNSW vector search** with RocksDB persistence for durable, high-performance retrieval
- **Multi-session and cross-agent** knowledge sharing
- **Production-ready**: written in Rust, self-deployable via Docker/docker-compose
- MCP-native with Python, JavaScript, Rust, and Go SDKs

It fits well alongside Private GPT, Hindsight, and SAGE in the Knowledge Management section as production infrastructure for agent memory.

Links:
- MCP Server: https://github.com/dakera-ai/dakera-mcp
- Deploy: https://github.com/dakera-ai/dakera-deploy
- Docs: https://github.com/dakera-ai/dakera-docs