### PR TITLE
Add MisakaNet to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
 - [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, MCP, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)
 - [Screenpipe](https://github.com/screenpipe/screenpipe): 24/7 local screen + microphone recording with OCR, audio transcription, and semantic search. Gives AI agents long-term context of everything you've seen, said, or heard. MCP server for Claude. 100% local, MIT licensed. ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social)
+- [MisakaNet](https://github.com/Ikalus1988/MisakaNet): Git-based distributed swarm memory for AI agents. Cross-agent lesson sharing via GitHub Issues — when one agent solves a problem, every node on the network learns from it. 104+ shared lessons, 21+ registered nodes. ![GitHub Repo stars](https://img.shields.io/github/stars/Ikalus1988/MisakaNet?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## What is MisakaNet?

MisakaNet is a Git-based distributed swarm memory for AI agents. When one agent solves a problem, every node on the network learns from it.

## Why it fits here

MisakaNet belongs in **Knowledge Management** because it's fundamentally about turning individual agent debugging sessions into shared, searchable knowledge across a distributed network:

- **104+ shared lessons** across 7 domains (devops, feishu, rag, claude, etc.)
- **21+ registered nodes** (Hermes, Claude, Codex, OpenClaw, OpenCode)
- **GitHub Issues as message bus** — zero infrastructure, built-in auth
- **Git for sync** — offline-first, conflict-resilient
- **Markdown lessons** — human-readable, git-diffable, searchable

## Links

- [GitHub](https://github.com/Ikalus1988/MisakaNet)
- [Wiki](https://github.com/Ikalus1988/MisakaNet/wiki)
- License: Apache 2.0