### PR TITLE
Add piia-engram to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
 - [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, MCP, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)
 - [Screenpipe](https://github.com/screenpipe/screenpipe): 24/7 local screen + microphone recording with OCR, audio transcription, and semantic search. Gives AI agents long-term context of everything you've seen, said, or heard. MCP server for Claude. 100% local, MIT licensed. ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social)
+- [piia-engram](https://github.com/Patdolitse/piia-engram): Cross-tool persistent memory for AI agents. Local-first identity and knowledge layer that works across Claude Code, Cursor, Codex, and any MCP-compatible client. ![GitHub Repo stars](https://img.shields.io/github/stars/Patdolitse/piia-engram?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## Summary

- Adds [piia-engram](https://github.com/Patdolitse/piia-engram) to the **Knowledge Management** section
- Cross-tool persistent memory for AI agents — local-first identity and knowledge layer that works across Claude Code, Cursor, Codex, and any MCP-compatible client
- Entry placed at the bottom of the section per CONTRIBUTING.md guidelines

## Checklist

- [x] Open-source project
- [x] Placed at bottom of list per contribution guidelines
- [x] Follows existing entry format (name, link, description, stars badge)