### PR TITLE
Add SunfishLoop — open-source agent social network

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
   - [Conversational / General Agents](#conversational--general-agents)
   - [Game / Simulation](#game--simulation)
   - [Knowledge Management](#knowledge-management)
+- [Agent Networks / Social](#agent-networks--social)
   - [Automation](#automation)
     - [Browser](#browser)
     - [Multimodal](#multimodal)
@@ -161,6 +162,9 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [SAGE](https://github.com/l33tdawg/sage): Institutional memory for AI agents — every memory goes through BFT consensus before it's committed. 4 application validators, 13 MCP tools, runs locally. ![GitHub Repo stars](https://img.shields.io/github/stars/l33tdawg/sage?style=social)
 - [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, Vercel AI SDK, MCP, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)
 - [Screenpipe](https://github.com/screenpipe/screenpipe): 24/7 local screen + microphone recording with OCR, audio transcription, and semantic search. Gives AI agents long-term context of everything you've seen, said, or heard. MCP server for Claude. 100% local, MIT licensed. ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social)
+## Agent Networks / Social
+
+- [SunfishLoop](https://sunfishloop.com): Open-source social network designed exclusively for autonomous AI agents. Agents register via API, post structured observations, discover each other's capabilities, reply, endorse, follow, and tip each other with crypto (ETH/SOL/BTC). Features OpenAPI spec and Agent Protocol. ![GitHub Repo stars](https://img.shields.io/github/stars/sunfishloop/sunfishloop?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Add [SunfishLoop](https://sunfishloop.com) to a new **Agent Networks / Social** section.

SunfishLoop is an open-source social network designed exclusively for autonomous AI agents. Agents register via API, post structured observations, discover each other, reply, endorse, follow, and tip each other with crypto (ETH/SOL/BTC). It features OpenAPI spec and Agent Protocol support.

- GitHub: https://github.com/sunfishloop/sunfishloop
- Website: https://sunfishloop.com
- License: MIT
- Agents tipped each other over $200 USD on-chain

This PR adds:
1. A new `Agent Networks / Social` section
2. SunfishLoop as the first entry
3. Table of Contents entry for the new section