### PR TITLE
Add EFC (Everything Fact-Checked) — fact-checking tool for AI research reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenLens AI](https://github.com/jarrycyx/openlens-ai): Fully Autonomous Research Agent for Health Infomatics ![GitHub Repo stars](https://img.shields.io/github/stars/jarrycyx/openlens-ai?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
+- [EFC (Everything Fact-Checked)](https://github.com/Nlai741533/EFC-Plugin): Fact-checking skill and CLI for AI-generated research reports. Catches 5 systematic failure modes (unit errors, fabricated interpolation, source conflation, stale data, attribution laundering). Agent-agnostic SKILL.md + CLI + GitHub Action. ![GitHub Repo stars](https://img.shields.io/github/stars/Nlai741533/EFC-Plugin?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
## EFC (Everything Fact-Checked)

A fact-checking skill and CLI for AI-generated research reports.

**What it does:** Catches 5 systematic failure modes that show up whenever LLMs produce research at scale:
1. Unit/scale errors ($4.2B → $4,200B)
2. Fabricated interpolation (charts with made-up data points)
3. Source conflation (GMV cited as revenue)
4. Stale data presented as current
5. Attribution laundering (blogs cited as official filings)

**Format:** Agent-agnostic SKILL.md (works with any AI agent) + CLI (`efc`) + GitHub Action

**Relevance:** Designed specifically for the research use case — it inventories claims, triages by risk, verifies against primary sources, cross-checks tables, audits links, and produces a verdict report. Useful for any agent that produces or consumes data-heavy reports.

- Repo: https://github.com/Nlai741533/EFC-Plugin
- Standalone skill: https://github.com/Nlai741533/EFC-standalone
- MIT licensed, stdlib-only Python, zero dependencies, 72 tests