### PR TITLE
Add machine (isolated Lima VM per project for coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ctop](https://github.com/aakashadesara/ctop): htop for AI coding agents. Monitor Claude Code and Codex CLI sessions with real-time CPU, memory, token usage, context window tracking, and cost estimates. Zero dependencies, pure Node.js. ![GitHub Repo stars](https://img.shields.io/github/stars/aakashadesara/ctop?style=social)
 - [Frontman](https://www.github.com/frontman-ai/frontman): Open-source AI coding agent that lives in your browser, hooks into your dev server, sees the live DOM, component tree, CSS, routes, and logs, then edits the actual source files with instant hot reload. ![GitHub Repo stars](https://img.shields.io/github/stars/frontman-ai/frontman?style=social)
 - [Maestro](https://github.com/RunMaestro/Maestro): Open-source desktop command center for running multiple AI coding agents (Claude Code, Codex, Gemini CLI, etc.) in parallel, with Cue event automation, Auto Run playbooks, Group Chat across local and remote agents, and a maestro-cli that agents can drive themselves. ![GitHub Repo stars](https://img.shields.io/github/stars/RunMaestro/Maestro?style=social)
+- [machine](https://github.com/katspaugh/machine): CLI that provisions one isolated Lima VM per GitHub project as a sandbox for Claude Code/Codex, with Docker, Node, and signed git preconfigured. ![GitHub Repo stars](https://img.shields.io/github/stars/katspaugh/machine?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds `machine`, an open-source (MIT) CLI that provisions one isolated Lima VM per GitHub project as a sandbox for Claude Code/Codex (Docker, Node, signed git preconfigured). Placed at the bottom of the Software Development section per the contribution guidelines, alongside existing agent-sandbox tools like Greywall and AgentsMesh. Site: https://runmachine.dev