### PR TITLE
Add eval-harness to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 
+- [eval-harness](https://github.com/nano-step/eval-harness): Behavior-regression testing for LLM agents and skills (opencode runner today, runner-pluggable): runs structured + prose eval cases against prompts/skills, diffs against a committed baseline, and gates PRs on cost-bounded regressions — with 4-class attribution (SKILL_CHANGED / FIXTURE_STALE / MODEL_CHANGED / UNKNOWN_DRIFT) when a regression lands. ![GitHub Repo stars](https://img.shields.io/github/stars/nano-step/eval-harness?style=social)
 ## Software Development
 
 - [MetaGPT](https://github.com/geekan/MetaGPT): The Multi-Agent Framework: First AI Software Company, Towards Natural Language Programming ![GitHub Repo stars](https://img.shields.io/github/stars/geekan/MetaGPT?style=social)


### PR DESCRIPTION
This PR adds [eval-harness](https://github.com/nano-step/eval-harness) to the **Testing and Evaluation** section.

**What it is**: A behavior-regression testing harness for LLM agents and skills. Unlike prompt-grading frameworks (Promptfoo, DeepEval) that score single responses, eval-harness diffs end-to-end agent runs against a committed baseline — so a prompt edit that *changes* behavior fails the build even if it still "scores well."

**Why it fits this list**:
- Open source, MIT, bash + jq + python3 stdlib only.
- Runner-pluggable (opencode runner shipped today, LangGraph/Claude Agent SDK on the v0.8.0 roadmap).
- Catches the four classic skill-regression classes with attribution tags (SKILL_CHANGED / FIXTURE_STALE / MODEL_CHANGED / UNKNOWN_DRIFT) so reviewers can disambiguate "did the skill change or did the model change?"
- Cost-bounded by default (`EVAL_BUDGET_USD=2.00` per run) so it's safe to gate PRs on.
- Ships a composite GitHub Action and a non-flaky stability check (3-sample majority, Mann-Whitney U significance test).

**Niche disclosure**: The project is ~1 month old with 4★ and 33 open issues. I won't pretend otherwise. But the maintainer is actively shipping (8 BLOCKER fixes in v0.4.2, all with regression tests), already accepted into 4 other awesome-lists via similar submissions, and the 4-class attribution design is, to my knowledge, novel for this layer of the stack. I'm happy to revise the description, re-position the entry, or close this PR if it doesn't meet the bar.

**Repo**: https://github.com/nano-step/eval-harness
**Docs**: https://github.com/nano-step/eval-harness/blob/main/docs/concepts.md
**Live eval fixtures**: https://github.com/nano-step/eval-harness/tree/main/.eval

Thanks for the curation work — this is my favorite list of agentic tooling.
