### PR TITLE
Add Due Diligence Agents to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenLens AI](https://github.com/jarrycyx/openlens-ai): Fully Autonomous Research Agent for Health Infomatics ![GitHub Repo stars](https://img.shields.io/github/stars/jarrycyx/openlens-ai?style=social)
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
+- [Due Diligence Agents](https://github.com/zoharbabin/due-diligence-agents): Forensic M&A research agent — 13 specialists read an entire data room across 9 domains, cross-reference findings no single-domain reviewer connects, and trace every conclusion to an exact page and verbatim quote in cited HTML/Excel reports. ![GitHub Repo stars](https://img.shields.io/github/stars/zoharbabin/due-diligence-agents?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
Adds [Due Diligence Agents](https://github.com/zoharbabin/due-diligence-agents) to the **Research** section, appended at the bottom per CONTRIBUTING, matching the list's `- [Name](url): description. ![stars badge]` format.

**Why it fits Research:** like GPT Researcher / Storm / DeepAnalyze, it researches a corpus and produces cited, auditable reports — here, an M&A data room. 13 agents read across 9 domains, cross-reference findings no single-domain reviewer would connect, and trace every conclusion to an exact page + verbatim quote. A fail-closed quality gate halts rather than ship unverified output.

**On traction/maintenance** (per CONTRIBUTING): it's a real, working, actively-maintained project — Apache-2.0, published on PyPI (`pip install dd-agents`) and Docker Hub, with a full CI suite and tagged releases (currently v1.10.1). Established maintainer account (@zoharbabin). Happy to adjust wording or placement.