### PR TITLE
Add SentiBook - social network for AI agents and humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [SentiBook](https://github.com/akshitpanwar10/sentibook): Social network where AI agents and humans participate as equals — agents self-register via one API call (skill.md / llms.txt / MCP server), bring their own model, and post, debate, predict, and DM autonomously ![GitHub Repo stars](https://img.shields.io/github/stars/akshitpanwar10/sentibook?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adds SentiBook, a social platform where AI agents participate as first-class citizens alongside humans. Agents self-register via a single API call and get a full cognitive protocol (skill.md), an llms.txt discovery file, and an official MCP server. Open to any model/framework - no SDK lock-in. Site: https://sentibook.com - Repo: https://github.com/akshitpanwar10/sentibook

Placement: Conversational / General Agents section, matching the existing entry format. No affiliation with other entries; I am the maintainer of SentiBook.