### PR TITLE
Add ChatCrystal to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [piia-engram](https://github.com/Patdolitse/piia-engram): Cross-tool persistent memory for AI agents. Local-first identity and knowledge layer that works across Claude Code, Cursor, Codex, and any MCP-compatible client. ![GitHub Repo stars](https://img.shields.io/github/stars/Patdolitse/piia-engram?style=social)
 - [MemClaw](https://github.com/caura-ai/caura-memclaw): Open-source governed shared memory for AI agent fleets with cross-agent recall, permissions, audit trails, and persistent memory.
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
+- [ChatCrystal](https://github.com/ZengLiangYi/ChatCrystal): Local-first AI PKM and MCP memory server for coding conversations. Imports Claude Code, Cursor, Codex CLI, Trae, and GitHub Copilot chats into structured notes, semantic search, tag graphs, Markdown exports, and reusable agent memory. ![GitHub Repo stars](https://img.shields.io/github/stars/ZengLiangYi/ChatCrystal?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Adds ChatCrystal to Knowledge Management.

ChatCrystal is a local-first AI PKM and MCP memory server for coding conversations. It imports Claude Code, Cursor, Codex CLI, Trae, and GitHub Copilot chats into structured notes, semantic search, tag graphs, Markdown exports, and reusable agent memory.

Review context:
- Website: https://zengliangyi.github.io/ChatCrystal/
- Repository: https://github.com/ZengLiangYi/ChatCrystal
- npm: `chatcrystal@0.5.4`
- Official MCP Registry: `io.github.ZengLiangYi/chatcrystal`
- Install: `npx -y chatcrystal mcp`