### PR TITLE
Add Novu Connect to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [Novu Connect](https://novu.co/connect): Gives one AI agent a synced presence across every messaging channel (Slack, Teams, WhatsApp), with external MCP servers connected mid-conversation (in-conversation authorization, session-level tool access). Open source, `npx novu connect`. ![GitHub Repo stars](https://img.shields.io/github/stars/novuhq/novu?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adding **Novu Connect**, placed at the bottom of the Conversational / General Agents section (alongside ClaudeClaw and MateClaw, which do similar multi-channel agent routing).

Novu Connect gives one AI agent a synced presence across every messaging channel (Slack, Teams, WhatsApp) and lets it connect external MCP servers mid-conversation with session-level tool access.

Meets the guidelines: open source (MIT), strong traction (Novu core has 39k+ GitHub stars), actively maintained, agent-ecosystem related.

- Website: https://novu.co/connect
- Source: https://github.com/novuhq/novu