### PR TITLE
Add agent-reliability to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 - [agent-qa](https://github.com/vostride/agent-qa): Self-improving agentic QA harness for web and mobile tests. Write tests in natural language, use memory to adapt to UI changes, and catch regressions before releases ship. ![GitHub Repo stars](https://img.shields.io/github/stars/vostride/agent-qa?style=social)
+- [agent-reliability](https://github.com/marsloting/agent-reliability): Production-tested mechanisms for the gap between "the agent said it worked" and "it actually worked": corrupt success, first-article inspection, compound decay, cross-domain re-read. Fork each rule into your CLAUDE.md / AGENTS.md.
 
 ## Software Development
 


### PR DESCRIPTION
This adds agent-reliability as a production reliability resource for agent operators.

It is not a toy demo; it collects mechanisms from running agents in production: corrupt success, first-article inspection, compound decay, and cross-domain re-read.

I placed it under Testing and Evaluation because the repo focuses on verifying agent outcomes and catching false done-claims. Happy to move it if another section fits better.

Validation:
- read README.md, CONTRIBUTING.md, and the existing section format
- git diff --check
- changed-file privacy scan
