### PR TITLE
Add 5dive to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [5dive](https://github.com/5dive-ai/5dive): Open-source self-hosted multi-agent runtime. Spawn a persistent team of autonomous agents on your own Linux box, driven from Telegram, off your existing Claude subscription. ![GitHub Repo stars](https://img.shields.io/github/stars/5dive-ai/5dive?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adds **5dive** to the *Conversational / General Agents* section (appended at the bottom per CONTRIBUTING).

5dive is an open-source, self-hosted multi-agent runtime: spawn a persistent team of autonomous agents on your own Linux box, each driven from Telegram, running off your existing Claude subscription. It fits this section as a persistent, multi-role general agent rather than a domain-specific or single-purpose tool.

**Meets the contribution bar:**
- ✅ Open source — MIT licensed: https://github.com/5dive-ai/5dive
- ✅ Actively maintained — commits this week
- ✅ Online & demonstrated launch — Product Hunt: https://www.producthunt.com/posts/5dive
- ✅ Agentic and English

Entry format matches the section (bullet + description + star badge). Thanks for maintaining the list!