### PR TITLE
Add weco-cli to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Dorothy](https://github.com/Charlie85270/Dorothy): Open-source desktop app to orchestrate multiple AI CLI agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, remote control, and MCP servers. ![GitHub Repo stars](https://img.shields.io/github/stars/Charlie85270/Dorothy?style=social)
 - [VibeGrid](https://github.com/jcanizalez/vibegrid): Terminal manager for AI coding agents with multi-agent grid, task queues, workflow automation, headless execution, inline diff review, and Claude Code hooks. ![GitHub Repo stars](https://img.shields.io/github/stars/jcanizalez/vibegrid?style=social)
 - [Greywall](https://github.com/GreyhavenHQ/greywall): Deny-by-default command sandbox for AI coding agents with filesystem isolation, network control via transparent proxy, built-in profiles for agents like Claude Code or OpenCode, and learning mode for auto-generating configs. ![GitHub Repo stars](https://img.shields.io/github/stars/GreyhavenHQ/greywall?style=social)
+- [weco-cli](https://github.com/WecoAI/weco-cli): Terminal agent that optimizes code via autoresearch — it edits a file, runs your eval, and keeps the change only if the metric improves. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/weco-cli?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [weco-cli](https://github.com/WecoAI/weco-cli) to Software Development — an open-source terminal agent that optimizes code via autoresearch: it edits a file, runs your eval, and keeps changes only if the metric improves. (AIDE is already listed under Research.) Thanks for maintaining the list!