### PR TITLE
Add SeaOtter / OtterScore to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 - [agent-qa](https://github.com/vostride/agent-qa): Self-improving agentic QA harness for web and mobile tests. Write tests in natural language, use memory to adapt to UI changes, and catch regressions before releases ship. ![GitHub Repo stars](https://img.shields.io/github/stars/vostride/agent-qa?style=social)
+- [SeaOtter / OtterScore](https://seaotter.ai): A hostile-by-default critic that grades AI agent output (code, docs, decisions — any modality) and its trajectory against your acceptance policy, returning a score, a band (ship / route to fix / quarantine / block), located flaws, and concrete fixes. Free self-serve eval API + hosted MCP server.
 
 ## Software Development
 


### PR DESCRIPTION
Adds **SeaOtter / OtterScore** to the Testing and Evaluation section.

OtterScore is a hostile-by-default critic that grades AI agent output (code, docs, decisions — any modality) and its trajectory against your acceptance policy, returning a score, a band (ship / route to fix / quarantine / block), located flaws, and concrete fixes — so agents iterate until they clear the gate. Free self-serve eval API + a hosted MCP server (also on the official MCP registry as `ai.seaotter/otterscore`).

- Web: https://seaotter.ai
- Docs: https://seaotter.ai/developers

One clean entry in the most relevant section; no duplicates.