### PR TITLE
Add Atris to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Cate](https://github.com/0-AI-UG/cate): Desktop IDE on an infinite zoomable canvas. Editors, terminals, browsers, and Claude Code agent panels float in spatial workspace instead of tabs; panels can dock or detach into separate windows. Electron + React + TypeScript, layout persists per project. ![GitHub Repo stars](https://img.shields.io/github/stars/0-AI-UG/cate?style=social)
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder): Local-first CLI coding agent built with React and Ink. ![GitHub Repo stars](https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social)
 - [zeroshot](https://github.com/the-open-engine/zeroshot): CLI that orchestrates a planner, an implementer, and independent validators in isolated environments ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-engine/zeroshot?style=social)
+- [Atris](https://github.com/atrislabs/atris): An operating system for AI work that turns any repo into a workspace an agent operates, with shared context, a plan/do/review loop, durable tasks, and verification that ends work on a real check. ![GitHub Repo stars](https://img.shields.io/github/stars/atrislabs/atris?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds **Atris** to the Software Development section.

Atris is an operating system for AI work: it turns any repo into a workspace an agent operates, with shared context, a plan/do/review loop, durable tasks, and verification that ends work on a real check instead of a promise. CLI install: `npm i -g atris`.

- GitHub: https://github.com/atrislabs/atris
- Website: https://atris.ai
- npm: https://www.npmjs.com/package/atris