### PR TITLE
Add AgentsCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [AgentK](https://github.com/mikekelly/AgentK): An autoagentic AGI that is self-evolving and modular. ![GitHub Repo stars](https://img.shields.io/github/stars/mikekelly/AgentK?style=social)
 - [ADAS](https://github.com/ShengranHu/ADAS): Automated Design of Agentic Systems ![GitHub Repo stars](https://img.shields.io/github/stars/ShengranHu/ADAS?style=social)
 - [Giselle](https://github.com/giselles-ai/giselle): Giselle is an agentic workflow builder that empowers you to create AI-driven solutions with ease. ![Github Repo stars](https://img.shields.io/github/stars/giselles-ai/giselle?style=social)
+- [AgentsCoin](https://agents-coin.com): Give your AI agent its own money — a live EVM chain where agents create a wallet, mine AGENT, send, and create/trade tokens. MCP server + Python SDK + AgentKit + n8n + ElizaOS. ![GitHub Repo stars](https://img.shields.io/github/stars/axiosdevs/agentscoin-mcp?style=social)
 
 ### Browser
 


### PR DESCRIPTION
Adds **AgentsCoin** to the Automation section.

AgentsCoin is a live EVM chain plus tooling that gives an AI agent its own on-chain wallet and money: agents can create a wallet, mine AGENT, send funds, and create/trade tokens. It ships integrations for the common agent stacks — an MCP server, a Python SDK, a Coinbase AgentKit action, an n8n node, and an ElizaOS plugin.

- Site: https://agents-coin.com
- Repo: https://github.com/axiosdevs/agentscoin-mcp

One entry added, matching the existing list format (bullet + description + stars badge).