### PR TITLE
Add Vestige to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [piia-engram](https://github.com/Patdolitse/piia-engram): Cross-tool persistent memory for AI agents. Local-first identity and knowledge layer that works across Claude Code, Cursor, Codex, and any MCP-compatible client. ![GitHub Repo stars](https://img.shields.io/github/stars/Patdolitse/piia-engram?style=social)
 - [MemClaw](https://github.com/caura-ai/caura-memclaw): Open-source governed shared memory for AI agent fleets with cross-agent recall, permissions, audit trails, and persistent memory.
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
+- [Vestige](https://github.com/samvallad33/vestige): Local-first cognitive memory for AI agents. FSRS-6 spaced-repetition decay, prediction-error gating, active forgetting, spreading activation, and a real-time 3D memory dashboard, all in one Rust binary that runs fully on your machine. ![GitHub Repo stars](https://img.shields.io/github/stars/samvallad33/vestige?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Adding Vestige under Knowledge Management.

Vestige is local-first cognitive memory for AI agents: FSRS-6 spaced-repetition decay, prediction-error gating, active forgetting, spreading activation, and a real-time 3D memory dashboard, all in one Rust binary that runs fully local.

- Repo: https://github.com/samvallad33/vestige
- Install: npm install -g vestige-mcp-server