### PR TITLE
Add h5i to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Cate](https://github.com/0-AI-UG/cate): Desktop IDE on an infinite zoomable canvas. Editors, terminals, browsers, and Claude Code agent panels float in spatial workspace instead of tabs; panels can dock or detach into separate windows. Electron + React + TypeScript, layout persists per project. ![GitHub Repo stars](https://img.shields.io/github/stars/0-AI-UG/cate?style=social)
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder): Local-first CLI coding agent built with React and Ink. ![GitHub Repo stars](https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social)
 - [zeroshot](https://github.com/the-open-engine/zeroshot): CLI that orchestrates a planner, an implementer, and independent validators in isolated environments ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-engine/zeroshot?style=social)
+- [h5i](https://github.com/h5i-dev/h5i): CLI that runs several coding agents (Claude Code, Codex) on the same task, each in its own isolated git worktree sandbox, has them peer-review each other, then a neutral verifier replays every candidate, runs the tests, and merges the one that passes. Run metadata (prompts, models, commands, logs, messages, verdict) is versioned in the repo under refs/h5i/*. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/h5i-dev/h5i?style=social)
 
 ## Research
 


### PR DESCRIPTION
This adds [h5i](https://github.com/h5i-dev/h5i) to the **Software Development** section.

h5i is an open-source Rust CLI that runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under refs/h5i/*.

The entry follows the existing format and ordering of the list.