### PR TITLE
Add agent-eval-kit to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)
 - [Manifest](https://github.com/mnfst/manifest): Open-source, real-time cost observability platform for AI agents. Track tokens, costs, messages, and model usage with a local-first dashboard. Supports 28+ LLM models, OTLP ingestion, self-hosted. ![GitHub Repo stars](https://img.shields.io/github/stars/mnfst/manifest?style=social)
 - [agent-qa](https://github.com/vostride/agent-qa): Self-improving agentic QA harness for web and mobile tests. Write tests in natural language, use memory to adapt to UI changes, and catch regressions before releases ship. ![GitHub Repo stars](https://img.shields.io/github/stars/vostride/agent-qa?style=social)
+- [agent-eval-kit](https://github.com/SeaOtterAI/agent-eval-kit): Open-source SDK + MCP for a hostile-by-default critic (OtterScore) that grades agent work — output and trajectory — against your acceptance policy and gates it before production (ship / route / quarantine / block). ![GitHub Repo stars](https://img.shields.io/github/stars/SeaOtterAI/agent-eval-kit?style=social)
 
 ## Software Development
 


### PR DESCRIPTION
Adds **[agent-eval-kit](https://github.com/SeaOtterAI/agent-eval-kit)** (Apache-2.0) to **Testing and Evaluation**.

Open-source SDK + MCP server for a hostile-by-default critic (OtterScore) that grades agent work — output and trajectory — against a written acceptance policy and gates it before production (ship / route to fix / quarantine / block). Fits alongside the existing eval/observability entries (Arize-Phoenix, EvoAgentX). Single fair entry, matching the section's markdown format.