### PR TITLE
Add Perseus to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [piia-engram](https://github.com/Patdolitse/piia-engram): Cross-tool persistent memory for AI agents. Local-first identity and knowledge layer that works across Claude Code, Cursor, Codex, and any MCP-compatible client. ![GitHub Repo stars](https://img.shields.io/github/stars/Patdolitse/piia-engram?style=social)
 - [MemClaw](https://github.com/caura-ai/caura-memclaw): Open-source governed shared memory for AI agent fleets with cross-agent recall, permissions, audit trails, and persistent memory.
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
+- [Perseus](https://github.com/Perseus-Computing-LLC/perseus): Local-first live context engine and MCP server that pre-resolves git, services, tests, and memory into a ready context briefing at session start (compile-before-context). MIT, PyPI: perseus-ctx. ![GitHub Repo stars](https://img.shields.io/github/stars/Perseus-Computing-LLC/perseus?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Adds Perseus to the bottom of the Knowledge Management section, following the contribution guidelines.

**What it is:** Perseus is an open-source (MIT), local-first live context engine and MCP server for AI coding agents. It pre-resolves git state, running services, tests, and memory into a ready context briefing at session start (compile-before-context), and exposes this to any MCP client.

**Guideline checklist:**
- Open source: yes (MIT) — https://github.com/Perseus-Computing-LLC/perseus
- In English: yes
- Related to the agentic ecosystem: yes — an MCP server / context layer for AI agents
- Maintained: yes — actively committed to
- Online: yes; also published on PyPI as `perseus-ctx`
- Adds value: a local-first context-compilation approach distinct from the existing memory/RAG entries
- Placement: added at the bottom of the Knowledge Management section, with the `?style=social` star badge matching the surrounding entries