### PR TITLE
add remoteopenclaw mcp to software development

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Cate](https://github.com/0-AI-UG/cate): Desktop IDE on an infinite zoomable canvas. Editors, terminals, browsers, and Claude Code agent panels float in spatial workspace instead of tabs; panels can dock or detach into separate windows. Electron + React + TypeScript, layout persists per project. ![GitHub Repo stars](https://img.shields.io/github/stars/0-AI-UG/cate?style=social)
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder): Local-first CLI coding agent built with React and Ink. ![GitHub Repo stars](https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social)
 - [zeroshot](https://github.com/the-open-engine/zeroshot): CLI that orchestrates a planner, an implementer, and independent validators in isolated environments ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-engine/zeroshot?style=social)
+- [RemoteOpenClaw MCP](https://github.com/aidevelopers2/remoteopenclaw-mcp): MCP server and CLI that searches 13,870+ MCP servers, 4,384+ skills, and plugins from your terminal or AI agent, no API key required. ![GitHub Repo stars](https://img.shields.io/github/stars/aidevelopers2/remoteopenclaw-mcp?style=social)
 
 ## Research
 


### PR DESCRIPTION
adds RemoteOpenClaw MCP at the bottom of the Software Development section.

it is an open source (MIT, TypeScript) MCP server and CLI that lets agents and developers search 13,870+ MCP servers, 4,384+ skills, and plugins from the terminal or from inside an AI agent. stdio transport, no API key required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)