### PR TITLE
feat: add Rolecraft to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Cate](https://github.com/0-AI-UG/cate): Desktop IDE on an infinite zoomable canvas. Editors, terminals, browsers, and Claude Code agent panels float in spatial workspace instead of tabs; panels can dock or detach into separate windows. Electron + React + TypeScript, layout persists per project. ![GitHub Repo stars](https://img.shields.io/github/stars/0-AI-UG/cate?style=social)
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder): Local-first CLI coding agent built with React and Ink. ![GitHub Repo stars](https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social)
 - [zeroshot](https://github.com/the-open-engine/zeroshot): CLI that orchestrates a planner, an implementer, and independent validators in isolated environments ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-engine/zeroshot?style=social)
+- [Rolecraft](https://github.com/sametcelikbicak/rolecraft): Zero-dependency CLI tool for managing SKILL.md files for 66+ AI coding agents. ![GitHub Repo stars](https://img.shields.io/github/stars/sametcelikbicak/rolecraft?style=social)
 
 ## Research
 


### PR DESCRIPTION
Add [Rolecraft](https://github.com/sametcelikbicak/rolecraft) — zero-dependency CLI tool for managing SKILL.md files for 66+ AI coding agents. Works with opencode, claude-code, cursor, and all spec-compliant agents.