### PR TITLE
Add issuebeam to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Cate](https://github.com/0-AI-UG/cate): Desktop IDE on an infinite zoomable canvas. Editors, terminals, browsers, and Claude Code agent panels float in spatial workspace instead of tabs; panels can dock or detach into separate windows. Electron + React + TypeScript, layout persists per project. ![GitHub Repo stars](https://img.shields.io/github/stars/0-AI-UG/cate?style=social)
 - [Nanocoder](https://github.com/Nano-Collective/nanocoder): Local-first CLI coding agent built with React and Ink. ![GitHub Repo stars](https://img.shields.io/github/stars/Nano-Collective/nanocoder?style=social)
 - [zeroshot](https://github.com/the-open-engine/zeroshot): CLI that orchestrates a planner, an implementer, and independent validators in isolated environments ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-engine/zeroshot?style=social)
+- [issuebeam](https://github.com/issuebeam/issuebeam) - Connects AI coding agents (Cursor, Claude Code, Copilot) directly to GitHub Issues via a zero-dependency Python CLI.
+
 
 ## Research
 


### PR DESCRIPTION
Hi! I'd like to add issuebeam to the list.

It's a lightweight, standard-library-only Python CLI designed to connect AI coding agents (like Cursor, Claude Code, and Copilot) directly to GitHub Issues, preventing bugs from getting lost in AI chat logs.

I have read the contribution guidelines and ordered the list alphabetically. Thank you!
