### PR TITLE
Add CorvinOS to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [CorvinOS](https://github.com/CorvinLabs/CorvinOS): Self-hosted agentic OS connecting Ollama and cloud LLMs to Discord, Telegram, WhatsApp, Slack, and Email — hash-chained audit log, per-user consent gate, and bot-disclosure built into the architecture. ![GitHub Repo stars](https://img.shields.io/github/stars/CorvinLabs/CorvinOS?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adds [CorvinOS](https://github.com/CorvinLabs/CorvinOS) — a self-hosted agentic OS connecting local Ollama models and cloud providers to Discord, Telegram, WhatsApp, Slack, and Email, with a hash-chained audit log, per-user consent gate, and bot-disclosure notice built into the architecture.

Re-submitting after #596 was closed without comment — happy to adjust format/wording if it doesn't fit the list's conventions.

License: Apache-2.0