### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [piia-engram](https://github.com/Patdolitse/piia-engram): Cross-tool persistent memory for AI agents. Local-first identity and knowledge layer that works across Claude Code, Cursor, Codex, and any MCP-compatible client. ![GitHub Repo stars](https://img.shields.io/github/stars/Patdolitse/piia-engram?style=social)
 - [MemClaw](https://github.com/caura-ai/caura-memclaw): Open-source governed shared memory for AI agent fleets with cross-agent recall, permissions, audit trails, and persistent memory.
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory): Local-first Rust CLI/TUI for AI-agent memory recall, forgetting, audit trails, and session consolidation. ![GitHub Repo stars](https://img.shields.io/github/stars/TerminallyLazy/Tree-Ring-Memory?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## Summary
- Add Tree Ring Memory to the Knowledge Management section
- Place it at the bottom of the existing agent-memory cluster

## Why it belongs
Tree Ring Memory is an open-source, local-first Rust CLI/TUI for AI-agent memory recall, forgetting, audit trails, and session consolidation. It complements the existing Knowledge Management entries by focusing on project-scoped memory lifecycle operations rather than vector search alone.

Current project proof points:
- Public GitHub repo with release artifacts and CI
- Public docs/landing page
- Homebrew tap for macOS ARM64 install
- Rust CLI/TUI with SQLite/FTS-backed memory operations

## Validation
- `git diff --check`
- Verified the project link returns HTTP 200
- Confirmed no existing Tree Ring Memory entry or PR in this repository

Note: I did not list `npx awesome-lint` as a passing gate because the unmodified repository already fails generic awesome-lint on existing repository-wide formatting/topic/license issues. This PR follows the current README entry style.