### PR TITLE
docs: add NULLA under Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [NULLA](https://github.com/Parad0x-Labs/nulla-local): Local-first, private AI agent with offline-verifiable action receipts; runs on your machine ![GitHub Repo stars](https://img.shields.io/github/stars/Parad0x-Labs/nulla-local?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adds NULLA, a local-first AI agent (Ollama-based, MIT, Alpha) that runs fully on the user's machine and signs an offline-verifiable receipt of each action (what it claimed vs. what actually ran).

Repo: https://github.com/Parad0x-Labs/nulla-local
