### PR TITLE
Add Argon to Testing and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Testing and Evaluation
 - [Voice Lab](https://github.com/saharmor/voice-lab): A comprehensive testing and evaluation framework for voice agents across language models, prompts, and agent personas. ![GitHub Repo stars](https://img.shields.io/github/stars/saharmor/voice-lab?style=social)
+- [Argon](https://github.com/argon-lab/argon): Versioned, branchable MongoDB for agents — dataset pins give every eval run byte-identical input, and per-agent sandboxes isolate writes so runs stay reproducible and undoable. ![GitHub Repo stars](https://img.shields.io/github/stars/argon-lab/argon?style=social)
 - [Open-RAG-Eval](https://github.com/vectara/open-rag-eval): an open source RAG evaluation framework that does not require golden answers, and can be used to evaluate performance of RAG tools connected to an AI Agent (Agentic RAG)
 - [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX): EvoAgentX is building a Self-Evolving Ecosystem of AI Agents, it will give you automated framework for evaluating and evolving agentic workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/EvoAgentX/EvoAgentX?style=social)
 - [Arize-Phoenix](https://github.com/Arize-ai/phoenix): Arize-Phoenix is an open source library for agent testing, evaluation and observability. ![GitHub Repo stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=social)


### PR DESCRIPTION
Adds [Argon](https://github.com/argon-lab/argon) under **Testing and Evaluation**.

Argon is an open-source (MIT) engine that gives AI agents versioned, branchable MongoDB. For evals specifically: dataset pins are immutable named states so every run forks byte-identical input, and per-agent sandboxes isolate writes so runs are reproducible and undoable.