### PR TITLE
Add Off Grid AI Desktop - local AI app with MCP connectors for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop): Open-source, local-first AI desktop app for Mac. Local LLM chat via llama.cpp with MCP connectors and approval-gated actions, plus image generation, voice, and memory/RAG - all on-device, no cloud. ![GitHub Repo stars](https://img.shields.io/github/stars/off-grid-ai/off-grid-ai-desktop?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
## What

Adds **Off Grid AI Desktop** to the **Conversational / General Agents** section, placed at the bottom of the section next to peers like OpenAgent and MateClaw (personal AI assistants with RAG, agent loops, and MCP tools).

Off Grid AI Desktop is an open-source (AGPL-3.0) local-first AI desktop app for Mac:

- Local LLM chat via llama.cpp - runs on-device, nothing routes through a cloud server
- MCP connectors with approval-gated actions (agentic tool use, human-in-the-loop)
- On-device image generation and voice
- Memory / RAG over your own data

Repo: https://github.com/off-grid-ai/off-grid-ai-desktop
Site: https://getoffgridai.co/desktop

Disclosure: I'm involved with the project.
