### PR TITLE
Add Ontheia to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Frameworks
 
+- [Ontheia](https://github.com/Ontheia/ontheia): Self-hosted, open-source AI agent platform — multi-provider (Claude, GPT, Gemini, Ollama), MCP-native tools, Agent Skills, visual Chain Engine, long-term memory (pgvector), scheduling, and agent-to-agent delegation. GDPR-compliant by architecture. AGPL-3.0. ![GitHub Repo stars](https://img.shields.io/github/stars/Ontheia/ontheia?style=social)
 - [OpenClaw](https://github.com/openclaw/openclaw): Open-source AI agent framework that turns LLMs into persistent, proactive personal AI agents with multi-channel messaging (Signal, Telegram, Discord, WhatsApp), cron scheduling, memory systems, MCP integration, skill plugins, sub-agent spawning, and browser automation. ![GitHub Repo stars](https://img.shields.io/github/stars/openclaw/openclaw?style=social)
 - [Hermes Agent](https://github.com/nousresearch/hermes-agent): The agent that grows with you 
 - [llama-agentic-system](https://github.com/meta-llama/llama-agentic-system): Agentic components of the Llama Stack APIs ![GitHub Repo stars](https://img.shields.io/github/stars/meta-llama/llama-agentic-system?style=social)


### PR DESCRIPTION
Adds **Ontheia** to the Frameworks section.

[Ontheia](https://github.com/Ontheia/ontheia) is a self-hosted, open-source AI agent platform — multi-provider (Claude, GPT, Gemini, Ollama), MCP-native tool integration, Agent Skills, a visual Chain Engine, long-term vector memory (pgvector), scheduling, and agent-to-agent delegation. GDPR-compliant by architecture, AGPL-3.0.

Single entry, alphabetized formatting consistent with the section. Thanks for maintaining the list!