### PR TITLE
docs: add Metis coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [zeroshot](https://github.com/the-open-engine/zeroshot): CLI that orchestrates a planner, an implementer, and independent validators in isolated environments ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-engine/zeroshot?style=social)
 - [h5i](https://github.com/h5i-dev/h5i): CLI that runs several coding agents (Claude Code, Codex) on the same task, each in its own isolated git worktree sandbox, has them peer-review each other, then a neutral verifier replays every candidate, runs the tests, and merges the one that passes. Run metadata (prompts, models, commands, logs, messages, verdict) is versioned in the repo under refs/h5i/*. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/h5i-dev/h5i?style=social)
 - [Paperclip](https://github.com/paperclipai/paperclip): Open-source platform to run coding agents as managed workers with tasks, approvals, budgets, and workspaces. ![GitHub Repo stars](https://img.shields.io/github/stars/paperclipai/paperclip?style=social)
+- [Metis](https://github.com/Wholiver/metis): Open-source terminal-first coding agent with project memory, repository search, verification workflows, an interactive TUI, JSON/RPC modes, and a Node.js SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/Wholiver/metis?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary
- add Metis to the Software Development section
- describe its terminal-first coding-agent workflow, project memory, repository search, verification, TUI, JSON/RPC modes, and SDK

## Validation
- `git diff --check`
- verified one Metis entry at the bottom of the Software Development section, per contribution guidelines