### PR TITLE
Add Tura to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [h5i](https://github.com/h5i-dev/h5i): CLI that runs several coding agents (Claude Code, Codex) on the same task, each in its own isolated git worktree sandbox, has them peer-review each other, then a neutral verifier replays every candidate, runs the tests, and merges the one that passes. Run metadata (prompts, models, commands, logs, messages, verdict) is versioned in the repo under refs/h5i/*. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/h5i-dev/h5i?style=social)
 - [Paperclip](https://github.com/paperclipai/paperclip): Open-source platform to run coding agents as managed workers with tasks, approvals, budgets, and workspaces. ![GitHub Repo stars](https://img.shields.io/github/stars/paperclipai/paperclip?style=social)
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai): Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, Kanban, and code review across multiple agent runtimes. ![GitHub Repo stars](https://img.shields.io/github/stars/777genius/agent-teams-ai?style=social)
-- [Tura](https://github.com/Tura-AI/tura): Local-first coding agent for terminal, TUI, and desktop workflows, with multi-provider models, tools, MCP, and persistent task state. ![GitHub Repo stars](https://img.shields.io/github/stars/Tura-AI/tura?style=social)
+- [Tura](https://github.com/Tura-AI/tura): A local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. ![GitHub Repo stars](https://img.shields.io/github/stars/Tura-AI/tura?style=social)
 
 ## Research
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [h5i](https://github.com/h5i-dev/h5i): CLI that runs several coding agents (Claude Code, Codex) on the same task, each in its own isolated git worktree sandbox, has them peer-review each other, then a neutral verifier replays every candidate, runs the tests, and merges the one that passes. Run metadata (prompts, models, commands, logs, messages, verdict) is versioned in the repo under refs/h5i/*. Rust, Apache-2.0. ![GitHub Repo stars](https://img.shields.io/github/stars/h5i-dev/h5i?style=social)
 - [Paperclip](https://github.com/paperclipai/paperclip): Open-source platform to run coding agents as managed workers with tasks, approvals, budgets, and workspaces. ![GitHub Repo stars](https://img.shields.io/github/stars/paperclipai/paperclip?style=social)
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai): Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, Kanban, and code review across multiple agent runtimes. ![GitHub Repo stars](https://img.shields.io/github/stars/777genius/agent-teams-ai?style=social)
+- [Tura](https://github.com/Tura-AI/tura): Local-first coding agent for terminal, TUI, and desktop workflows, with multi-provider models, tools, MCP, and persistent task state. ![GitHub Repo stars](https://img.shields.io/github/stars/Tura-AI/tura?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

Adds [Tura](https://github.com/Tura-AI/tura) to the bottom of the **Software Development** section, following the contribution guide.

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Benchmark evidence: https://turaai.net/benchmark

## Why it fits

- Open-source AGPL-3.0 coding agent for software-development work
- Maintained project with 70 GitHub stars and 617 lifetime commits at submission time
- The repository and generated GitHub-stars badge both return HTTP 200

## Validation

- Exact duplicate searches for `Tura-AI/tura` returned zero code, Issue, PR, and Discussion results before submission
- `git diff --check` passed
- One README line added at the bottom of the matching section
- The pull request has no base conflict and no requested review change

## Disclosure

I am affiliated with the Tura project. I used AI assistance to read the repository rules, verify eligibility and duplicate state, update this listing from Tura's root README, and run the checks; I reviewed the final submission.