### PR TITLE
Add Orkas to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [ClaudeClaw](https://github.com/sbusso/claudeclaw): Persistent agent orchestrator plugin for Claude Code — multi-channel routing (Slack, WhatsApp, Telegram), OS-level sandbox isolation, composable extensions, structured memory, webhook triggers ![GitHub Repo stars](https://img.shields.io/github/stars/sbusso/claudeclaw?style=social)
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
+- [Orkas](https://github.com/Orkas-AI/Orkas): Local-first multi-agent desktop application where a Commander coordinates specialist agents for research, coding, data analysis, documents, and media; MIT-licensed with bring-your-own model keys. ![GitHub Repo stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
## Summary

- Adds [Orkas](https://github.com/Orkas-AI/Orkas) to the **Conversational / General Agents** section.
- Orkas is an MIT-licensed, local-first multi-agent desktop application where a Commander coordinates specialist agents for research, coding, data analysis, documents, and media.
- The entry follows the existing single-line format and is placed at the bottom of the section.

## Why it now meets the curation criteria

- The repository now has more than two months of public history, hundreds of stars, and more than 20 forks.
- It is actively maintained and has an English README with installation instructions, screenshots, architecture notes, and an MIT license.
- It provides a desktop interface for coordinated specialist agents rather than a thin single-model chat wrapper.

## Previous submission

PR #454 was automatically closed by botbocks in May 2026, when the repository was about ten days old. This resubmission uses a shorter factual description and is being made after the project has demonstrated traction and continued maintenance.

## Account migration

This replaces #648, which was closed only to move the source fork from Orkas-AI to BlueSkyID666. The proposed content is unchanged.
