### PR TITLE
Add ZenBrain (neuroscience-inspired agent memory) to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [MemClaw](https://github.com/caura-ai/caura-memclaw): Open-source governed shared memory for AI agent fleets with cross-agent recall, permissions, audit trails, and persistent memory.
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
 - [CodeAlmanac](https://github.com/AlmanacCode/codealmanac): Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac?style=social)
+- [ZenBrain](https://github.com/zensation-ai/zenbrain): Neuroscience-inspired memory layer for AI agents — a 7-layer cognitive architecture with sleep-style consolidation, FSRS spaced-repetition retention, Hebbian association, and active forgetting. Open source (Apache-2.0), self-hostable, zero-dependency TypeScript core. ![GitHub Repo stars](https://img.shields.io/github/stars/zensation-ai/zenbrain?style=social)
 
 ## Automation
 


### PR DESCRIPTION
Adds **ZenBrain** to the **Knowledge Management** section.

ZenBrain is an open-source (Apache-2.0), self-hostable memory layer for AI agents, built on a neuroscience-inspired **7-layer cognitive architecture** — with sleep-style consolidation, FSRS spaced-repetition retention, Hebbian association, and active forgetting. It sits naturally alongside peers already listed here (Hindsight, Statewave, SAGE).

- **Repo:** https://github.com/zensation-ai/zenbrain
- **License:** Apache-2.0 · TypeScript, zero-dependency core
- **Maintained:** 7 releases (v0.1.0 → v0.3.4), active this week
- Placed at the **bottom of the Knowledge Management** section, per the contribution guidelines.

Checklist: open source ✓ · English ✓ · maintained ✓ · agent-memory tooling ✓ · adds a distinct approach (cognitive/neuroscience memory model) ✓
