### PR TITLE
Add AgentServices — x402-paid data APIs for AI agents (54 services, 37 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
   - [Automation](#automation)
     - [Browser](#browser)
     - [Multimodal](#multimodal)
+  - [Agent Data & Payment APIs](#agent-data--payment-apis)
 
 ## Frameworks
 
@@ -202,3 +203,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Steel Browser](https://github.com/steel-dev/steel-browser): Open-source browser infrastructure for AI agents with session-backed automation, extraction, screenshots/PDFs, an AI-native CLI, and a reusable steel-browser skill. ![GitHub Repo stars](https://img.shields.io/github/stars/steel-dev/steel-browser?style=social)
 - [Actionbook](https://github.com/actionbook/actionbook): Parallel Action CLI for AI agents. Run 50 actions across 20 sites at onece. ![GitHub Repo stars](https://img.shields.io/github/stars/actionbook/actionbook?style=social)
 - [invisible-playwright](https://github.com/feder-cr/invisible_playwright): Playwright wrapper for a stealth-patched Firefox 150 binary. Drop-in replacement returning native Playwright Browser objects, fingerprint spoofing in the C++ source. ![GitHub Repo stars](https://img.shields.io/github/stars/feder-cr/invisible_playwright?style=social)
+
+## Agent Data & Payment APIs
+
+- [AgentServices](https://github.com/vbkotecha/aiservices-api): Production x402-paid API platform with 54 services, 97 endpoints, and 37 MCP tools for AI agents. Covers crypto market data, DeFi analytics, macro indicators, SEO, deep research, and more. Micropayments via USDC on Base. ![GitHub Repo stars](https://img.shields.io/github/stars/vbkotecha/aiservices-api?style=social)


### PR DESCRIPTION
## What

Added a new **Agent Data & Payment APIs** section featuring AgentServices — a production x402-paid API platform providing data services for AI agents.

## Why

As agent frameworks mature, the bottleneck shifts from orchestration to **data access and monetization**. AgentServices is the first production platform combining:

- **54 data services** (crypto market data, DeFi analytics, macro indicators, SEO, deep research, onchain intelligence)
- **97 REST endpoints** with OpenAPI specs designed for agent consumption
- **37 MCP tools** via a streamable-http MCP server
- **x402 micropayments** (USDC on Base) — agents pay per-call autonomously

This fills a gap in the awesome-agents list: tools that give agents real-world data access with built-in payment infrastructure.

## Details

- Open source: https://github.com/vbkotecha/aiservices-api
- MCP server: https://agentservices.to/.well-known/mcp.json
- Live API: https://api.agentservices.to
- Health: https://agentservices.to/health

Happy to adjust placement or description to fit the list conventions.