### PR TITLE
Add lucinate to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenAgent](https://github.com/the-open-agent/openagent): Next-generation personal AI assistant powered by LLM, RAG and agent loops. Supports computer-use, browser-use, coding agent, 30+ model providers, visual workflow builder, and MCP tools. Self-hostable with admin dashboard. ![GitHub Repo stars](https://img.shields.io/github/stars/the-open-agent/openagent?style=social)
 - [MateClaw](https://github.com/matevip/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/matevip/mateclaw?style=social)
 - [Orkas](https://github.com/Orkas-AI/Orkas): Local-first multi-agent desktop application where a Commander coordinates specialist agents for research, coding, data analysis, documents, and media; MIT-licensed with bring-your-own model keys. ![GitHub Repo stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)
+- [lucinate](https://github.com/lucinate-ai/lucinate): Multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs — with routines, multi-agent switching, tool call cards, and local agent skills, all in the TUI. Apache-2.0 licensed. ![GitHub Repo stars](https://img.shields.io/github/stars/lucinate-ai/lucinate?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
### Add [lucinate](https://github.com/lucinate-ai/lucinate)

A multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and any OpenAI-compatible backend — with routines, multi-agent switching, tool call cards, and local agent skills, all in the TUI.

**Why it fits:** lucinate is a conversational AI agent interface that runs in the terminal, supporting multiple agent backends (OpenClaw, Hermes) and local LLM providers (Ollama, vLLM, LM Studio). It enables users to chat with, switch between, and manage agents from a single TUI without leaving the terminal.

**Traction:** Actively maintained with regular releases (v1.23.0), Apache 2.0 license, cross-platform install scripts + Homebrew, CI green.