### PR TITLE
Add Garcon to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai): Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, Kanban, and code review across multiple agent runtimes. ![GitHub Repo stars](https://img.shields.io/github/stars/777genius/agent-teams-ai?style=social)
 - [Tura](https://github.com/Tura-AI/tura): A local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. ![GitHub Repo stars](https://img.shields.io/github/stars/Tura-AI/tura?style=social)
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
+- [Garcon](https://github.com/cfal/garcon): Self-hosted browser and mobile workspace for running and steering parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions, with integrated terminal, files, diff review, Git/PR workflows, mobile approvals, and cross-agent transfers ![GitHub Repo stars](https://img.shields.io/github/stars/cfal/garcon?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [Garcon](https://github.com/cfal/garcon), a GPL-3.0 self-hosted browser and mobile workspace for running and steering parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions. It includes an integrated terminal, files, diff review, Git and pull-request workflows, mobile approvals, and cross-agent transfers. The entry follows the existing description and stars-badge format and is appended to Software Development.

Disclosure: I maintain Garcon.
