### PR TITLE
Add IWE to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [MemClaw](https://github.com/caura-ai/caura-memclaw): Open-source governed shared memory for AI agent fleets with cross-agent recall, permissions, audit trails, and persistent memory.
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
 - [CodeAlmanac](https://github.com/AlmanacCode/codealmanac): Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac?style=social)
+- [IWE](https://github.com/iwe-org/iwe): Markdown knowledge graph for you and your AI agents — editor LSP plus CLI and MCP server so agents can search, retrieve, and refactor plain-text notes. ![GitHub Repo stars](https://img.shields.io/github/stars/iwe-org/iwe?style=social)
 
 ## Automation
 


### PR DESCRIPTION
IWE is an open-source (Apache-2.0, Rust) markdown knowledge-management tool. Its MCP server (`iwec`) turns a local directory of markdown notes into a knowledge graph agents can search, retrieve, create, and refactor — the same plain files you edit in your editor through its LSP. Supports stdio and streamable HTTP transports.

Repo: https://github.com/iwe-org/iwe · MCP docs: https://iwe.md/docs/agentic/mcp/
