### PR TITLE
Add Zoom Search to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
 - [CodeAlmanac](https://github.com/AlmanacCode/codealmanac): Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac?style=social)
 - [IWE](https://github.com/iwe-org/iwe): Markdown knowledge graph for you and your AI agents — editor LSP plus CLI and MCP server so agents can search, retrieve, and refactor plain-text notes. ![GitHub Repo stars](https://img.shields.io/github/stars/iwe-org/iwe?style=social)
+- [Zoom Search](https://github.com/goofrey/zoom-search): Source-first search and evidence tool for AI agents, with query rewriting, domain zoom-in, sourced answers, and MCP server support. ![GitHub Repo stars](https://img.shields.io/github/stars/goofrey/zoom-search?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## Summary\n- add Zoom Search to the Knowledge Management section\n- keep the change to a single README entry\n\n## Why\nZoom Search is an open-source search and evidence tool for AI agents with query rewriting, domain zoom-in, sourced answers, and MCP server support.