### PR TITLE
Add OpenCodeReview to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Tura](https://github.com/Tura-AI/tura): A local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. ![GitHub Repo stars](https://img.shields.io/github/stars/Tura-AI/tura?style=social)
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
 - [fractal](https://github.com/plasma-ai/fractal): Runs Claude Code, Codex, and other coding agents as a recursive tree of autonomous loops. Each node works in its own git worktree and can delegate subtasks to child nodes, while a live terminal UI lets operators inspect and steer the tree within configurable time, cost, and depth limits. ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
+- [OpenCodeReview](https://github.com/alibaba/open-code-review): An open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaba/open-code-review?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [OpenCodeReview](https://github.com/alibaba/open-code-review) (`alibaba/open-code-review`, Apache-2.0) to the **Software Development** section, placed at the bottom of the list per the contribution guidelines.

OpenCodeReview is an open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. Maintained under the Alibaba org. Follows the existing list entry format.