### PR TITLE
Add Dahrk to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Tura](https://github.com/Tura-AI/tura): A local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. ![GitHub Repo stars](https://img.shields.io/github/stars/Tura-AI/tura?style=social)
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
 - [fractal](https://github.com/plasma-ai/fractal): Runs Claude Code, Codex, and other coding agents as a recursive tree of autonomous loops. Each node works in its own git worktree and can delegate subtasks to child nodes, while a live terminal UI lets operators inspect and steer the tree within configurable time, cost, and depth limits. ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
+- [Dahrk](https://github.com/dahrkai/dahrk-node): Runs a multi-stage agent workflow per Linear issue on nodes you own, giving each stage its own runtime (Claude Code, Codex, Pi), model, prompt, and git worktree. Plain TypeScript sequences the stages ![GitHub Repo stars](https://img.shields.io/github/stars/dahrkai/dahrk-node?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [Dahrk](https://github.com/dahrkai/dahrk-node) at the bottom of Software Development, per the guidelines.

Dahrk runs a multi-stage agent workflow per Linear issue on nodes you own, giving each stage its own runtime (Claude Code, Codex, Pi), model, prompt, and git worktree. Plain TypeScript sequences the stages.

Against your criteria:
- Open source: the node client is Apache-2.0 and published on npm as `dahrk-node`. The hub it connects to is hosted, which the README states up front.
- Maintained: yes.
- Traction: this is the weak spot. The public node repo is young and sits at ⭐7. Close this if that misses your bar.

I maintain the project.