### PR TITLE
Add hermes-llmwiki to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
 - [CodeAlmanac](https://github.com/AlmanacCode/codealmanac): Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac?style=social)
 - [IWE](https://github.com/iwe-org/iwe): Markdown knowledge graph for you and your AI agents — editor LSP plus CLI and MCP server so agents can search, retrieve, and refactor plain-text notes. ![GitHub Repo stars](https://img.shields.io/github/stars/iwe-org/iwe?style=social)
+- [hermes-llmwiki](https://github.com/chancelu/hermes-llmwiki): Karpathy-native local Markdown wiki memory provider for Hermes Agent. Zero-infrastructure 3-layer architecture (Raw → Chronicle → Compiled), bidirectional read/write, Obsidian-compatible vault, schema-driven. PyPI: `pip install hermes-llmwiki`. ![GitHub Repo stars](https://img.shields.io/github/stars/chancelu/hermes-llmwiki?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## What is hermes-llmwiki?

[hermes-llmwiki](https://github.com/chancelu/hermes-llmwiki) is a **Karpathy-native local Markdown wiki memory provider** for [Hermes Agent](https://github.com/nousresearch/hermes-agent). It turns your local Markdown vault into a compounding knowledge system — no Docker, no cloud, no vector DB.

### Why it matters for the AI agent ecosystem

Every serious agent user hits the same wall: **the agent forgets everything between sessions**. Existing fixes fall into two camps:
1. **SaaS lock-in** (Honcho, Mem0, Supermemory) — you don't own your data
2. **Infrastructure hell** (Qdrant + Redis + Docker) — overkill for a personal memory layer

Karpathy's insight (from his 5000+ star gist) is that **RAG is fundamentally broken for agent memory**: the LLM rediscovers knowledge every single query instead of building on what it already knows. The fix is a structured wiki the agent can **both read from and write to**.

### Technical highlights

| Feature | hermes-llmwiki |
|---------|---------------|
| Architecture | Karpathy 3-layer (Raw → Chronicle → Compiled) |
| Dependencies | Python + ripgrep + optional SQLite |
| Data format | AI-First Markdown with frontmatter |
| Vault compat | Obsidian, Logseq, any Markdown editor |
| Schema | SCHEMA.md drives vault structure |
| Direction | Bidirectional (agent reads + writes) |
| Install | pip install hermes-llmwiki |

### PyPI release

v0.1.0 is live: https://pypi.org/project/hermes-llmwiki/

---
**Note:** Placed in the Knowledge Management section alongside IWE, CodeAlmanac, and piia-engram.