### PR TITLE
docs: add Agent Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
 - [fractal](https://github.com/plasma-ai/fractal): Runs Claude Code, Codex, and other coding agents as a recursive tree of autonomous loops. Each node works in its own git worktree and can delegate subtasks to child nodes, while a live terminal UI lets operators inspect and steer the tree within configurable time, cost, and depth limits. ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
 - [OpenCodeReview](https://github.com/alibaba/open-code-review): An open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaba/open-code-review?style=social)
+- [Agent Console](https://github.com/Perseon-Lab/agent-console): Open-source browser mission control for Hermes-powered AI agents, with chat, session visibility, cron jobs, skills, voice controls, and read-only mission runs. ![GitHub Repo stars](https://img.shields.io/github/stars/Perseon-Lab/agent-console?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds Agent Console to the Software Development section.

Agent Console is an open-source browser mission control surface for Hermes-powered AI agents. It gives operators a single local UI for chat, session visibility, cron jobs, skills, voice controls, and read-only mission runs.

Validation:
- Reviewed the README diff locally
- Ran `git diff --check`
