### PR TITLE
Add Entroly to Software Development tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
 - [fractal](https://github.com/plasma-ai/fractal): Runs Claude Code, Codex, and other coding agents as a recursive tree of autonomous loops. Each node works in its own git worktree and can delegate subtasks to child nodes, while a live terminal UI lets operators inspect and steer the tree within configurable time, cost, and depth limits. ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
 - [OpenCodeReview](https://github.com/alibaba/open-code-review): An open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaba/open-code-review?style=social)
+- [Entroly](https://github.com/juyterman1000/entroly): Context-control and token-pruning MCP server for AI coding agents. Helps developers reduce token usage via information-theoretic context optimization, maintains prompt cache stability, and provides zero-cost local verification (WITNESS). ![GitHub Repo stars](https://img.shields.io/github/stars/juyterman1000/entroly?style=social)
 
 ## Research
 


### PR DESCRIPTION
Hi!

I'd like to suggest adding Entroly to the Software Development section.

Entroly is a local-first context-control plane and Model Context Protocol (MCP) server designed to help developers build and run AI coding agents more efficiently. It provides:
- **Context-control & token-pruning**: Reduces prompt context sizes using information-theoretic selection (BM25, entropy, and dependency-graph knapsack).
- **Prompt cache stability**: Optimizes prompt prefixes to support provider cache discounts.
- **Local verification**: Uses a lightweight, local claim verifier (WITNESS) to guard against agent hallucinations with zero LLM API cost.

It fits well alongside other developer/agent tools in the Software Development category. Thank you!
