### PR TITLE
Add OpenCandle to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
 - [Cynative](https://github.com/cynative/cynative):  Deep cybersecurity research agent for your cloud, code and runtime. Read-only, sandboxed. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
+- [OpenCandle](https://github.com/Kahtaf/OpenCandle): Open-source, read-only financial research agent with live market data, inspectable evidence, local portfolios, and terminal and browser interfaces. ![GitHub Repo stars](https://img.shields.io/github/stars/Kahtaf/OpenCandle?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
Adding [OpenCandle](https://github.com/Kahtaf/OpenCandle) to the bottom of the Research section.

I built OpenCandle as a read-only financial research agent. It pulls current quotes, filings, options, macro, crypto, and sentiment data before answering. It also shows where the data came from and flags stale or unavailable providers. You can run it in a terminal or through its local browser interface.

The repo has been public since March 2026 and has 15 releases and four contributors. The npm and Pi package currently reports about 1,600 monthly downloads. It is MIT licensed and includes English docs, screenshots, and first-run instructions.

I checked for an existing entry, kept the change to one README line, verified the links, and ran `git diff --check`.

Disclosure: I maintain OpenCandle.
