### PR TITLE
Add AIWorkHub to software development agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
 - [fractal](https://github.com/plasma-ai/fractal): Runs Claude Code, Codex, and other coding agents as a recursive tree of autonomous loops. Each node works in its own git worktree and can delegate subtasks to child nodes, while a live terminal UI lets operators inspect and steer the tree within configurable time, cost, and depth limits. ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
 - [OpenCodeReview](https://github.com/alibaba/open-code-review): An open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaba/open-code-review?style=social)
+- [AIWorkHub](https://github.com/shrec/AIWorkHub): Open-source, repository-native control plane for coordinating Codex, Claude, Copilot, DeepSeek, and GLM coding agents with task DAGs, isolated workers, durable context, source intelligence, and evidence-based review. ![GitHub Repo stars](https://img.shields.io/github/stars/shrec/AIWorkHub?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

Adds AIWorkHub to the bottom of the **Software Development** section.

AIWorkHub is an open-source, repository-native control plane for coordinating
multiple coding-agent families. It provides dependency-aware tasks, isolated
workers, durable repository context, structural source intelligence and an
evidence-based manager review loop.

The entry follows the existing format and includes the repository star badge.
