### PR TITLE
Add BitFun to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [blade-deepseek](https://github.com/echoVic/blade-deepseek): A DeepSeek-native terminal coding agent in Rust with OS-level sandboxing, persistent goal mode, background tasks, and verification gates ![GitHub Repo stars](https://img.shields.io/github/stars/echoVic/blade-deepseek?style=social)
 - [fractal](https://github.com/plasma-ai/fractal): Runs Claude Code, Codex, and other coding agents as a recursive tree of autonomous loops. Each node works in its own git worktree and can delegate subtasks to child nodes, while a live terminal UI lets operators inspect and steer the tree within configurable time, cost, and depth limits. ![GitHub Repo stars](https://img.shields.io/github/stars/plasma-ai/fractal?style=social)
 - [OpenCodeReview](https://github.com/alibaba/open-code-review): An open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaba/open-code-review?style=social)
+- [BitFun](https://github.com/GCWing/BitFun): Open-source desktop agent with a Rust runtime for real repositories, browser, terminal, and desktop execution, extensible through MCP, Skills, and custom agents. ![GitHub Repo stars](https://img.shields.io/github/stars/GCWing/BitFun?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

- Add BitFun to the bottom of the Software Development list
- Describe its Rust-powered desktop agent runtime and supported execution surfaces

## Project fit

- Open source under the MIT license
- English README, documentation, releases, and contribution guide
- Actively maintained, with 1.4k+ stars and 160+ forks at submission time
- Focused on agentic software development while also supporting broader desktop work

Disclosure: I maintain BitFun.