### PR TITLE
Add Caesar to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
 - [Cynative](https://github.com/cynative/cynative):  Deep cybersecurity research agent for your cloud, code and runtime. Read-only, sandboxed. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
-- [Caesar](https://github.com/jasonzliang/caesar-agent): Autonomous research agent that builds a knowledge graph during web exploration via a Perceive-Think-Act loop, then refines drafts through a Generator-Verifier loop with adversarial query synthesis. Multi-provider via litellm. ![GitHub Repo stars](https://img.shields.io/github/stars/jasonzliang/caesar-agent?style=social)
+- [Caesar](https://github.com/jasonzliang/caesar-agent): Autonomous research agent that builds a knowledge graph during web exploration via a Perceive-Think-Act loop, then refines drafts through adversarial artifact synthesis. Multi-provider via litellm. ![GitHub Repo stars](https://img.shields.io/github/stars/jasonzliang/caesar-agent?style=social)
 
 ## Conversational / General Agents
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): first agentic LLM for autonomous data science, supporting specific data tasks and data-oriented deep research (produce analyst-grade research reports). [![GitHub Repo stars](https://img.shields.io/github/stars/ruc-datalab/DeepAnalyze?style=social&label=Code+Stars)](https://github.com/ruc-datalab/DeepAnalyze)
 - [AIDE](https://github.com/WecoAI/aideml): AI-Driven Exploration — ML engineering agent that uses tree search to automate experiment design, code generation, and evaluation against any metric. ![GitHub Repo stars](https://img.shields.io/github/stars/WecoAI/aideml?style=social)
 - [Cynative](https://github.com/cynative/cynative):  Deep cybersecurity research agent for your cloud, code and runtime. Read-only, sandboxed. ![GitHub Repo stars](https://img.shields.io/github/stars/cynative/cynative?style=social)
+- [Caesar](https://github.com/jasonzliang/caesar-agent): Autonomous research agent that builds a knowledge graph during web exploration via a Perceive-Think-Act loop, then refines drafts through a Generator-Verifier loop with adversarial query synthesis. Multi-provider via litellm. ![GitHub Repo stars](https://img.shields.io/github/stars/jasonzliang/caesar-agent?style=social)
 
 ## Conversational / General Agents
 


### PR DESCRIPTION
Adds [Caesar](https://github.com/jasonzliang/caesar-agent) to the Research section, at the bottom per the guidelines.

Caesar builds a knowledge graph during web traversal, with a policy switching between depth-first expansion, backtracking and targeted search, then refines drafts recurrently, each producing an orthogonal challenge against its own gaps before merging. Same neighbourhood as GPT Researcher and Storm; the graph construction and the adversarial step are what differ from single-pass RAG.

Apache-2.0 (`LICENSE`, GitHub metadata, PyPI). 128 commits since 1 May 2026; first PyPI release 0.4.17 on 7 Aug. Not a wrapper: 0.85 MB of Python in `caesar/` and `rome/`, plus a FastAPI service and Next.js UI under `web_server/`. Self-hosted; users bring their own LLM key via litellm. Paper: [arXiv:2604.20855](https://arxiv.org/abs/2604.20855).

Traction, stated plainly: 2 stars, 1 fork, created 1 May 2026. Your guidelines list that as a closing criterion. Against it, the method is peer-reviewable and the implementation is complete and installable.

#403 and #433 linked this URL before the repository existed (created 1 May at 10:27 UTC, after #433 closed at 02:08), so both pointed at a dead link.

I am the author.
