### PR TITLE
Add Ouroboros (Agent OS) to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [OpenCodeReview](https://github.com/alibaba/open-code-review): An open-source hybrid code reviewer combining deterministic rules with an LLM agent (tool-use, line-level comments); self-hostable, bring-your-own model. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaba/open-code-review?style=social)
 - [BitFun](https://github.com/GCWing/BitFun): Open-source desktop agent with a Rust runtime for real repositories, browser, terminal, and desktop execution, extensible through MCP, Skills, and custom agents. ![GitHub Repo stars](https://img.shields.io/github/stars/GCWing/BitFun?style=social)
 - [CompozyOS](https://github.com/compozy/compozy): Open-source operating system for AI agents — plug in the agent CLIs you already use and run them as a team on loops and schedules, with shared memory, permissions and approvals ![GitHub Repo stars](https://img.shields.io/github/stars/compozy/compozy?style=social)
+- [Ouroboros (Agent OS)](https://github.com/Q00/ouroboros): Local-first Agent OS for spec-first AI coding — a Socratic interview crystallizes intent into an immutable seed spec before code, then a 3-stage evaluation gate (mechanical → semantic → multi-model consensus) verifies the build. Works across Claude Code, Codex CLI, OpenCode, Gemini, Kiro, Copilot, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/Q00/ouroboros?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [Q00/ouroboros](https://github.com/Q00/ouroboros) under **Software Development**.

Ouroboros is a local-first Agent OS for spec-first AI coding: a Socratic interview crystallizes intent into an immutable seed spec before code, then a 3-stage evaluation gate (mechanical -> semantic -> multi-model consensus) verifies the build. It works across Claude Code, Codex CLI, OpenCode, Gemini, Kiro, Copilot, and other CLI runtimes.

Named **"Ouroboros (Agent OS)"** to disambiguate from the existing `razzant/ouroboros` entry already listed under *Conversational / General Agents* -- different project, same name.

- Repo: https://github.com/Q00/ouroboros
- PyPI: https://pypi.org/project/ouroboros-ai/
- License: MIT
- Added at the bottom of the Software Development section per CONTRIBUTING.md.