### PR TITLE
Add Open Index to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
 - [CodeAlmanac](https://github.com/AlmanacCode/codealmanac): Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac?style=social)
 - [IWE](https://github.com/iwe-org/iwe): Markdown knowledge graph for you and your AI agents — editor LSP plus CLI and MCP server so agents can search, retrieve, and refactor plain-text notes. ![GitHub Repo stars](https://img.shields.io/github/stars/iwe-org/iwe?style=social)
+- [Open Index](https://github.com/DrDroidLab/open-index): Open-source context layer for domain-specialized agents, with structured knowledge graphs, hybrid search, MCP read/write tools, and continuously updated data from connectors. ![GitHub Repo stars](https://img.shields.io/github/stars/DrDroidLab/open-index?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## Summary

- add Open Index to the Knowledge Management category
- describe its structured context graph, hybrid search, MCP tools, and connectors
- include the standard GitHub stars badge

Open Index: https://github.com/DrDroidLab/open-index