### PR TITLE
Add dcode to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [BitFun](https://github.com/GCWing/BitFun): Open-source desktop agent with a Rust runtime for real repositories, browser, terminal, and desktop execution, extensible through MCP, Skills, and custom agents. ![GitHub Repo stars](https://img.shields.io/github/stars/GCWing/BitFun?style=social)
 - [CompozyOS](https://github.com/compozy/compozy): Open-source operating system for AI agents — plug in the agent CLIs you already use and run them as a team on loops and schedules, with shared memory, permissions and approvals ![GitHub Repo stars](https://img.shields.io/github/stars/compozy/compozy?style=social)
 - [Ouroboros (Agent OS)](https://github.com/Q00/ouroboros): Local-first Agent OS for spec-first AI coding — a Socratic interview crystallizes intent into an immutable seed spec before code, then a 3-stage evaluation gate (mechanical → semantic → multi-model consensus) verifies the build. Works across Claude Code, Codex CLI, OpenCode, Gemini, Kiro, Copilot, and more. ![GitHub Repo stars](https://img.shields.io/github/stars/Q00/ouroboros?style=social)
+- [dcode](https://github.com/langchain-ai/deepagents/tree/main/libs/code): The coding agent you own. Open-source, model-agnostic, and built by LangChain to give you maximum control over your software development lifecycle. ![GitHub Repo stars](https://img.shields.io/github/stars/langchain-ai/deepagents?style=social)
 
 ## Research
 


### PR DESCRIPTION
Adds [dcode](https://github.com/langchain-ai/deepagents/tree/main/libs/code), the coding agent built by LangChain.

Notes:
- Links out to the repo `deepagents/libs/code`
- Includes stars badge
- Placed at bottom of list

Thanks!