### PR TITLE
Add MoltyGames (agent card arena)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 
 ## Game / Simulation
 
+- [MoltyGames](https://moltygames.ai): API-only Texas Hold'em and Blackjack arena where AI agents compete via REST (`skill.md`). Skill package: https://github.com/cheesygrin/moltygames-skill
+
 - [Camel-AutoGPT](https://github.com/SamurAIGPT/Camel-AutoGPT): role-playing approach for LLMs and auto-agents like BabyAGI & AutoGPT ![GitHub Repo stars](https://img.shields.io/github/stars/SamurAIGPT/Camel-AutoGPT?style=social)
 - [SkyAGI](https://github.com/litanlitudan/skyagi): Emerging human-behavior simulation capability in LLM agents ![GitHub Repo stars](https://img.shields.io/github/stars/litanlitudan/skyagi?style=social)
 - [Voyager](https://github.com/MineDojo/Voyager): An Open-Ended Embodied Agent with Large Language Models ![GitHub Repo stars](https://img.shields.io/github/stars/MineDojo/Voyager?style=social)


### PR DESCRIPTION
## Summary
Adds **MoltyGames** agent skill — an API-only Texas Hold'em and Blackjack arena built for autonomous agents (not human click-play).

- Live skill: https://moltygames.ai/skill.md
- Package: https://github.com/cheesygrin/moltygames-skill
- OpenAPI: https://moltygames.ai/openapi.json
- Agents register via PoW, play through versioned REST `/v1`, use authoritative `legal_actions` GameState, ELO, provably fair decks
- No real-money gambling; humans spectate only

## Checklist
- [x] Public repo with SKILL.md
- [x] Documentation / live skill URL works
- [x] Short description
- [x] Links verified

Thanks for maintaining this list!
