### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [BitFun](https://github.com/GCWing/BitFun): Open-source desktop agent with a Rust runtime for real repositories, browser, terminal, and desktop execution, extensible through MCP, Skills, and custom agents. ![GitHub Repo stars](https://img.shields.io/github/stars/GCWing/BitFun?style=social)
 - [CompozyOS](https://github.com/compozy/compozy): Open-source operating system for AI agents — plug in the agent CLIs you already use and run them as a team on loops and schedules, with shared memory, permissions and approvals ![GitHub Repo stars](https://img.shields.io/github/stars/compozy/compozy?style=social)
 - [Ouroboros (Agent OS)](https://github.com/Q00/ouroboros): A Socratic interview gates the spec on an ambiguity score, then one command drives execution, a staged evaluation gate, and a budgeted evolution loop that runs the semantic stage only. ![GitHub Repo stars](https://img.shields.io/github/stars/Q00/ouroboros?style=social)
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key required, with 56 tools (browser, filesystem, git, memory, vision), MCP support, and 5-layer local memory. macOS, Linux, and Windows. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
 
 ## Research
 


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent, and thanks for maintaining this great list.

Atomic Agent is a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork, with no account or API key required to install. It ships 56 tools (browser, filesystem, git, memory, vision), MCP support, and a 5-layer local memory, and runs on macOS, Linux, and Windows.

- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT)
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- Install: `curl -fsSL https://atomicagent.io/install | sh`

Added to the bottom of the Software Development section per the contributing guidelines. My team would be thrilled if you'd add us. Thanks for the consideration!
