### PR TITLE
Add Lians to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Statewave](https://github.com/smaramwbc/statewave): Open-source memory runtime for AI agents that transforms events into structured memories, enabling memory evolution, consolidation, supersession, and long-term context management across agent workflows. ![GitHub Repo stars](https://img.shields.io/github/stars/smaramwbc/statewave?style=social)
 - [CodeAlmanac](https://github.com/AlmanacCode/codealmanac): Self-updating repo wiki for AI coding agents that tracks project conversations, decisions, and context locally inside the repository. ![GitHub Repo stars](https://img.shields.io/github/stars/AlmanacCode/codealmanac?style=social)
 - [IWE](https://github.com/iwe-org/iwe): Markdown knowledge graph for you and your AI agents — editor LSP plus CLI and MCP server so agents can search, retrieve, and refactor plain-text notes. ![GitHub Repo stars](https://img.shields.io/github/stars/iwe-org/iwe?style=social)
+- [Lians](https://github.com/Lians-ai/Lians): Local-first long-term memory for AI agents, with an MCP server, multi-language SDKs, temporal recall, and integrations for Codex, Gemini CLI, Cursor, and OpenCode. ![GitHub Repo stars](https://img.shields.io/github/stars/Lians-ai/Lians?style=social)
 
 ## Automation
 


### PR DESCRIPTION
## Summary

Adds [Lians](https://github.com/Lians-ai/Lians) to the bottom of the Knowledge Management section, following the contribution guidelines.

Lians is an actively maintained Apache-2.0 agent-memory project with a released v0.5.0, local-first storage, temporal recall, MCP, multiple SDKs, and working integrations for major coding-agent clients. The entry links directly to the open-source repository and uses the list's existing stars-badge format.

## Verification

- repository and badge URLs return HTTP 200
- `git diff --check` passes
- confirmed there is no existing Lians entry or PR

This change was prepared with AI assistance and reviewed before submission.