### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [CompozyOS](https://github.com/compozy/compozy): Open-source operating system for AI agents — plug in the agent CLIs you already use and run them as a team on loops and schedules, with shared memory, permissions and approvals ![GitHub Repo stars](https://img.shields.io/github/stars/compozy/compozy?style=social)
 - [Ouroboros (Agent OS)](https://github.com/Q00/ouroboros): A Socratic interview gates the spec on an ambiguity score, then one command drives execution, a staged evaluation gate, and a budgeted evolution loop that runs the semantic stage only. ![GitHub Repo stars](https://img.shields.io/github/stars/Q00/ouroboros?style=social)
 - [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key required, with 56 tools (browser, filesystem, git, memory, vision), MCP support, and 5-layer local memory. macOS, Linux, and Windows. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
+- [SandBase CLI](https://github.com/sandbaseai/cli): Agent-first CLI that gives coding agents a unified interface to 2,000+ AI models, multimodal generation, isolated sandboxes, and MCP tools. ![GitHub Repo stars](https://img.shields.io/github/stars/sandbaseai/cli?style=social)
 
 ## Research
 


### PR DESCRIPTION
## What

Add SandBase CLI to the Software Development section. It gives coding agents one CLI for 2,000+ AI models, multimodal generation, isolated sandboxes, and MCP tools.

## Why it meets the guidelines

- Open source under Apache-2.0
- Actively maintained; latest npm release is v0.1.14
- Demonstrated usage: 1,776 npm downloads in the latest completed monthly reporting window and 109 in the latest completed week
- Directly supports agent workflows, including Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and Windsurf
- Added at the bottom of the relevant list as requested

Disclosure: I am affiliated with the project. AI assistance was used to prepare this contribution.