### PR TITLE
Add 5dive to Conversational / General Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [MateClaw](https://github.com/mateaix/mateclaw): Open-source personal AI operating system on Spring Boot + Spring AI Alibaba — one JAR ships a web admin, desktop app (bundled JRE 21), embeddable widget, and 8 IM channels sharing the same agent. ![GitHub Repo stars](https://img.shields.io/github/stars/mateaix/mateclaw?style=social)
 - [Orkas](https://github.com/Orkas-AI/Orkas): Local-first multi-agent desktop application where a Commander coordinates specialist agents for research, coding, data analysis, documents, and media; MIT-licensed with bring-your-own model keys. ![GitHub Repo stars](https://img.shields.io/github/stars/Orkas-AI/Orkas?style=social)
 - [Ouroboros](https://github.com/razzant/ouroboros): Self-hosted general-purpose agent with durable identity and memory, reviewed self-modification, specialist subagent swarms, and desktop or headless operation. ![GitHub Repo stars](https://img.shields.io/github/stars/razzant/ouroboros?style=social)
+- [5dive](https://github.com/5dive-ai/5dive): Run a company of AI agents on a server you own — named agents on an org chart with a shared backlog, handing off work and pinging your phone only when a human must decide. ![GitHub Repo stars](https://img.shields.io/github/stars/5dive-ai/5dive?style=social)
 
 ## Game / Simulation
 


### PR DESCRIPTION
Adds **5dive** to *Conversational / General Agents*, appended at the bottom of the section per CONTRIBUTING.

5dive is an open-source, self-hosted runtime for a persistent team of agents: you spin up named agents on your own Linux box, put them on an org chart with a shared backlog, and they hand work between each other and only ping a human when a decision actually needs one. It sits with ClaudeClaw / Orkas / Ouroboros rather than in Frameworks — it is a running team, not a library you build one with.

Against the contribution bar:
- Open source, MIT — https://github.com/5dive-ai/5dive
- Traction: 50 stars, 7 forks, and it is already listed in [awesome-cli-coding-agents](https://github.com/bradAGI/awesome-cli-coding-agents) and [awesome-llm-agents](https://github.com/kaushikb11/awesome-llm-agents)
- Maintained: pushed today; commits on 58 of the last 62 days
- English, online, agent-native, and not a duplicate of anything on the list

I filed #562 in June and you closed it on the traction criterion — that was the right call at the time. Re-filing now that the repo clears the bar rather than re-arguing the old PR.
