### PR TITLE
Add Keen Code to Software Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [CompozyOS](https://github.com/compozy/compozy): Open-source operating system for AI agents — plug in the agent CLIs you already use and run them as a team on loops and schedules, with shared memory, permissions and approvals ![GitHub Repo stars](https://img.shields.io/github/stars/compozy/compozy?style=social)
 - [Ouroboros (Agent OS)](https://github.com/Q00/ouroboros): A Socratic interview gates the spec on an ambiguity score, then one command drives execution, a staged evaluation gate, and a budgeted evolution loop that runs the semantic stage only. ![GitHub Repo stars](https://img.shields.io/github/stars/Q00/ouroboros?style=social)
 - [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key required, with 56 tools (browser, filesystem, git, memory, vision), MCP support, and 5-layer local memory. macOS, Linux, and Windows. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
+- [Keen Code](https://github.com/mochow13/keen-code): Open-source, context-aware terminal coding agent written in Go with multiple providers, Turn Memory for controllable cross-turn tool-output retention, skill-driven MCP integration, subagents, Agent Skills, and hashline edits. ![GitHub Repo stars](https://img.shields.io/github/stars/mochow13/keen-code?style=social)
 
 ## Research
 


### PR DESCRIPTION
## Summary

Adds [Keen Code](https://github.com/mochow13/keen-code) to the bottom of the **Software Development** section.

Keen Code is an open-source, context-aware terminal coding agent written in Go. It supports multiple AI providers, subagents, Agent Skills, MCP servers, controllable tool-output retention, and hashline edits.

## Why it adds value

- **Turn Memory:** Multi-turn conversations retain a bounded subset of tool-interaction signals by default instead of replaying all raw outputs. Users can explicitly switch tool-output retention between compact and full modes. [Documentation](https://mochow13.github.io/keen-code/docs/turn-memory.html)
- **Skill-driven MCP:** MCP servers are exposed through generated Agent Skills rather than loading every MCP tool definition into context upfront or relying on semantic tool search. [Documentation](https://mochow13.github.io/keen-code/docs/mcp-skills.html)
- **Multi-provider:** Supports Gemini, OpenAI, Anthropic, DeepSeek, and other providers.
- **Developer-focused:** Includes subagents, permission-aware tools, hashline edits, sessions, and multi-agent orchestration.

## Contribution criteria

- Open source under the MIT License
- Maintained and actively developed
- 59 GitHub stars and 9 forks at submission time
- English documentation and public releases
- Listed in other curated coding-agent and developer-tool directories

Website: https://mochow13.github.io/keen-code/