### PR TITLE
docs: add agent-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Awesome Agents is a curated list of open-source tools and products to build AI a
 - [Ouroboros (Agent OS)](https://github.com/Q00/ouroboros): A Socratic interview gates the spec on an ambiguity score, then one command drives execution, a staged evaluation gate, and a budgeted evolution loop that runs the semantic stage only. ![GitHub Repo stars](https://img.shields.io/github/stars/Q00/ouroboros?style=social)
 - [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key required, with 56 tools (browser, filesystem, git, memory, vision), MCP support, and 5-layer local memory. macOS, Linux, and Windows. ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
 - [Keen Code](https://github.com/mochow13/keen-code): Open-source, context-aware terminal coding agent written in Go with multiple providers, Turn Memory for controllable cross-turn tool-output retention, skill-driven MCP integration, subagents, Agent Skills, and hashline edits. ![GitHub Repo stars](https://img.shields.io/github/stars/mochow13/keen-code?style=social)
+- [agent-scripts](https://github.com/ejboy/agent-scripts): Local-first CLI wrappers (`mvn-lite`, `npm-lite`, `go-lite`) that reduce build and test logs by up to 99%, conserving coding-agent context windows.
 
 ## Research
 


### PR DESCRIPTION
## Summary

Adds [agent-scripts](https://github.com/ejboy/agent-scripts) to the bottom of the **Software Development** section.

agent-scripts is a local-first collection of CLI utilities for AI-assisted development. Its core wrappers, `mvn-lite` and `npm-lite`, reduce build and test output noise so coding agents retain more useful context.

## Why it adds value

- **Context-efficient:** Compacts build and test logs while preserving useful failure information.
- **Local-first:** Runs locally without requiring a hosted service or account.
- **Developer-focused:** Provides predictable CLI commands that are easy for developers and coding agents to discover and use.
- **Practical tooling:** Includes utilities for browser automation, VS Code extension testing, and local repository discovery.

## Contribution criteria

- Open source under the MIT License
- English documentation and installation instructions
- Actively maintained, with recent commits and a v0.2.0 release
- Directly supports AI-assisted software development
- Added at the bottom of the Software Development section per the contribution guidelines

Repository: https://github.com/ejboy/agent-scripts
